### PR TITLE
Fix MET event

### DIFF
--- a/VUEs.json
+++ b/VUEs.json
@@ -411,20 +411,20 @@
     },
     {
         "hugoGeneSymbol": "MET",
-        "transcriptId": "ENST00000241453",
+        "transcriptId": "ENST00000397752",
         "genomicLocationDescription": "Indels and substitutions flanking exon 14 (e.g. 7:116411926_116412083del)",
         "defaultEffect": "splice",
         "comment": "Skipping of exon 14",
         "context": "Actionable in NSCLC",
         "revisedProteinEffects": [
             {
-                "variant": "13:g.28608217_28608218insCCAAACTCTAAATTTTCTCTTGGAAACTCCCATTTGAGATCATATTCATATTCTCTG",
-                "transcriptId": "ENST00000241453",
-                "genomicLocation":"13,28608217,28608218,-,CCAAACTCTAAATTTTCTCTTGGAAACTCCCATTTGAGATCATATTCATATTCTCTG",
-                "vepPredictedProteinEffect": "p.X594_splice",
+                "variant": "7:g.116411926_116412083del",
+                "transcriptId": "ENST00000397752",
+                "genomicLocation":"7,116411926,116412083,-,CCAAACTCTAAATTTTCTCTTGGAAACTCCCATTTGAGATCATATTCATATTCTCTG",
+                "vepPredictedProteinEffect": "p.X972_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "revisedProteinEffect": "p.E598_F612dup",
-                "revisedVariantClassification": "In_Frame_Ins",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "In_Frame_Del",
                 "pubmedId": 27343443,
                 "referenceText": "Schrock et al., 2014",
                 "confirmed": false

--- a/VUEs.json
+++ b/VUEs.json
@@ -420,7 +420,7 @@
             {
                 "variant": "7:g.116411926_116412083del",
                 "transcriptId": "ENST00000397752",
-                "genomicLocation":"7,116411926,116412083,-,CCAAACTCTAAATTTTCTCTTGGAAACTCCCATTTGAGATCATATTCATATTCTCTG",
+                "genomicLocation":"7,116411926,116412083,TACGATGCAAGAGTACACACTCCTCATTTGGATAGGCTTGTAAGTGCCCGAAGTGTAAGCCCAACTACAGAAATGGTTTCAAATGAATCTGTAGACTACCGAGCTACTTTTCCAGAAGGTATATTTCAGTTTATTGTTCTGAGAAATACCTATACATA, -",
                 "vepPredictedProteinEffect": "p.X972_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.D963_D1010del",


### PR DESCRIPTION
- Fixed the MET event that had data from the FLT3 event rather than its own information
- Reannotated with correct protein effect for an exon 14 skip
- This hopefully should also fix the genome nexus link so that it links to the MET event rather than the FLT3 one