### PR TITLE
Variant count by patient

### DIFF
--- a/VUEs.json
+++ b/VUEs.json
@@ -23,15 +23,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 3,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2383
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 466
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 334
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 3,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 428
                     }
                 }
             },
@@ -49,17 +56,24 @@
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 7,
+                        "somaticVariantsCount": 5,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2383
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 466
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 334
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 5,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 428
                     }
                 }
             },
@@ -77,17 +91,24 @@
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 4,
+                        "somaticVariantsCount": 3,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2383
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 466
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 334
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 3,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 428
                     }
                 }
             }
@@ -114,18 +135,25 @@
                 "confirmed": true,
                 "counts": {
                     "mskimpact": {
-                        "germlineVariantsCount": 2,
+                        "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 9706
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 5978
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 852
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 8
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 5140
                     }
                 }
             }
@@ -155,15 +183,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 1828
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 848
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 279
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 4
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 758
                     }
                 }
             }
@@ -193,15 +228,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 41890
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1217
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 1,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 3863
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 1
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1109
                     }
                 }
             }
@@ -229,17 +271,24 @@
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 9,
+                        "somaticVariantsCount": 7,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 15609
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2082
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 7,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 806
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 7,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2148
                     }
                 }
             }
@@ -269,15 +318,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -297,15 +353,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -325,15 +388,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -351,17 +421,24 @@
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 2,
+                        "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -381,15 +458,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -409,15 +493,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -437,15 +528,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -465,15 +563,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -493,15 +598,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -519,17 +631,24 @@
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 3,
+                        "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -549,15 +668,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -577,15 +703,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -605,15 +738,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -633,15 +773,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -661,15 +808,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -689,15 +843,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -717,15 +878,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -745,15 +913,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -773,15 +948,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -801,15 +983,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -829,15 +1018,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             },
@@ -857,15 +1053,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 3283
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 751
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 455
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 664
                     }
                 }
             }
@@ -895,15 +1098,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -923,15 +1133,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -951,15 +1168,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -979,15 +1203,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -1007,15 +1238,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -1035,15 +1273,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -1063,15 +1308,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -1091,15 +1343,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -1117,17 +1376,24 @@
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 21,
+                        "somaticVariantsCount": 16,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 14,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -1147,15 +1413,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -1175,15 +1448,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -1201,17 +1481,24 @@
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 49,
+                        "somaticVariantsCount": 38,
                         "unknownVariantsCount": 1,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 34,
+                        "unknownVariantsCount": 1,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -1231,15 +1518,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -1259,15 +1553,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -1287,15 +1588,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -1315,15 +1623,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -1341,17 +1656,24 @@
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 27,
+                        "somaticVariantsCount": 19,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
-                        "unknownVariantsCount": 2,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "unknownVariantsCount": 1,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 14,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -1371,15 +1693,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             },
@@ -1399,15 +1728,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2142
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 141
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 313
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 122
                     }
                 }
             }
@@ -1435,17 +1771,24 @@
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 5,
+                        "somaticVariantsCount": 2,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2994
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 99
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 453
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 2,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 86
                     }
                 }
             }
@@ -1473,17 +1816,24 @@
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 3,
+                        "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 1906
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 89
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 328
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 1
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 83
                     }
                 }
             }
@@ -1514,15 +1864,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 6175
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1512
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 616
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 6
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1288
                     }
                 }
             },
@@ -1540,18 +1897,25 @@
                 "confirmed": false,
                 "counts": {
                     "mskimpact": {
-                        "germlineVariantsCount": 8,
+                        "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 6175
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1512
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 616
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 6
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1288
                     }
                 }
             },
@@ -1572,15 +1936,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 6175
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1512
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 616
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 6
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1288
                     }
                 }
             },
@@ -1601,15 +1972,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 6175
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1512
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 616
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 6
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1288
                     }
                 }
             },
@@ -1630,15 +2008,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 6175
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1512
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 616
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 6
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1288
                     }
                 }
             },
@@ -1659,15 +2044,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 6175
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1512
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 616
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 6
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1288
                     }
                 }
             },
@@ -1688,15 +2080,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 6175
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1512
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 616
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 6
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1288
                     }
                 }
             },
@@ -1717,15 +2116,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 6175
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1512
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 616
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 6
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1288
                     }
                 }
             }
@@ -1756,15 +2162,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2539
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 407
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 305
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 351
                     }
                 }
             },
@@ -1782,18 +2195,25 @@
                 "confirmed": false,
                 "counts": {
                     "mskimpact": {
-                        "germlineVariantsCount": 5,
-                        "somaticVariantsCount": 3,
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 2,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2539
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 407
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 305
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 351
                     }
                 }
             }
@@ -1824,15 +2244,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 4066
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 587
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 504
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 1
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 532
                     }
                 }
             },
@@ -1853,15 +2280,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 4066
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 587
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 504
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 1
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 532
                     }
                 }
             },
@@ -1879,18 +2313,25 @@
                 "confirmed": false,
                 "counts": {
                     "mskimpact": {
-                        "germlineVariantsCount": 2,
+                        "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 4066
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 587
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 504
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 1
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 532
                     }
                 }
             }
@@ -1921,15 +2362,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 1337
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 195
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 247
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 156
                     }
                 }
             }
@@ -1957,18 +2405,25 @@
                 "confirmed": false,
                 "counts": {
                     "mskimpact": {
-                        "germlineVariantsCount": 1,
-                        "somaticVariantsCount": 14,
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 12,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2833
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 818
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 2,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 358
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 11,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 729
                     }
                 }
             },
@@ -1987,17 +2442,24 @@
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 2,
+                        "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 2833
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 818
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 358
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 729
                     }
                 }
             }
@@ -2025,18 +2487,25 @@
                 "confirmed": false,
                 "counts": {
                     "mskimpact": {
-                        "germlineVariantsCount": 15,
+                        "germlineVariantsCount": 0,
                         "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 1601
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 98
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 148
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 86
                     }
                 }
             }
@@ -2067,15 +2536,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 1288
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 18
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 205
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 20
                     }
                 }
             },
@@ -2093,18 +2569,25 @@
                 "confirmed": false,
                 "counts": {
                     "mskimpact": {
-                        "germlineVariantsCount": 1,
+                        "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 1288
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 18
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 205
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 20
                     }
                 }
             }
@@ -2132,18 +2615,25 @@
                 "confirmed": false,
                 "counts": {
                     "mskimpact": {
-                        "germlineVariantsCount": 2,
+                        "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 296
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 88
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2
                     }
                 }
             }
@@ -2174,15 +2664,22 @@
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 1134
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 9
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 181
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 8
                     }
                 }
             }
@@ -2210,17 +2707,24 @@
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 11,
+                        "somaticVariantsCount": 9,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 99293,
-                        "geneSampleCount": 6256
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1512
                     },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalSampleCount": 10115,
-                        "geneSampleCount": 515
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 1
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 6,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1346
                     }
                 }
             }

--- a/scripts/download_files.py
+++ b/scripts/download_files.py
@@ -7,7 +7,7 @@ import json
 url = "https://api.github.com/repos/cBioPortal/datahub/git/trees/master?recursive=1"
 
 # Target path to save the files
-target_path = "./files/"
+target_path = "./files/tcga"
 
 # Send a GET request to the GitHub API
 response = requests.get(url)
@@ -22,21 +22,31 @@ tcga_dirs = [dir for dir in directories if dir['path'].endswith("tcga_pan_can_at
 # Print the count of such directories
 print(f"Found {len(tcga_dirs)} directories.")
 
-# Go to each directory and download "data_mutations.txt"
+# Go to each directory "data_mutations.txt" and "data_clinical_sample.txt"
 for directory in tcga_dirs:
     # Construct the raw URL of the file
     print(directory['path'][7:])
-    file_url = f"https://media.githubusercontent.com/media/cBioPortal/datahub/master/{directory['path']}/data_mutations.txt"
+    mutation_file_url = f"https://media.githubusercontent.com/media/cBioPortal/datahub/master/{directory['path']}/data_mutations.txt"
+    clinical_file_url = f"https://media.githubusercontent.com/media/cBioPortal/datahub/master/{directory['path']}/data_clinical_sample.txt"
     
-    # Send a GET request to the raw URL
-    file_response = requests.get(file_url)
+    mutation_file_response = requests.get(mutation_file_url)
+    clinical_file_response = requests.get(clinical_file_url)
 
-    # If the file exists, the status code of the response will be 200
-    if file_response.status_code == 200:
-        # Save the file with the directory's name
-        filename = os.path.join(target_path, directory['path'].split('/')[-1] + ".txt")
-        with open(filename, 'wb') as f:
-            f.write(file_response.content)
-        print(f"Downloaded file to {filename}")
+    if mutation_file_response.status_code == 200:
+        mutation_filename = os.path.join(target_path, directory['path'].split('/')[-1] + "_mutations.txt")
+        with open(mutation_filename, 'wb') as f:
+            f.write(mutation_file_response.content)
+        print(f"Downloaded file to {mutation_filename}")
+    else:
+        print(f"No 'data_mutations.txt' found in {directory['path']}")
+    
+    if clinical_file_response.status_code == 200:
+        clinical_filename = os.path.join(target_path, directory['path'].split('/')[-1] + "_clinical_samples.txt")
+        with open(clinical_filename, 'wb') as f:
+            lines = clinical_file_response.content.splitlines()
+            for line in lines[4:]:
+                f.write(line + b'\n')
+
+        print(f"Downloaded file to {clinical_filename}")
     else:
         print(f"No 'data_mutations.txt' found in {directory['path']}")

--- a/scripts/variant_count.py
+++ b/scripts/variant_count.py
@@ -1,48 +1,76 @@
-import pandas as pd
 import json
-import glob
+import os
+import pandas as pd
+from typing import List
 
-# Get a list of all TXT files in the mskimpact and tcga folders
-mskimpact_files = glob.glob('./files/mskimpact/*.txt')
-tcga_files = glob.glob('./files/tcga/*.txt')
 
-# Create maps for variants count
-mskimpactCounts = {'germlineVariantsCount': {}, 'somaticVariantsCount': {}, 'unknownVariantsCount': {}, 'totalSampleCount': 0, 'sampleCountByGene': {}}
-tcgaCounts = {'germlineVariantsCount': {}, 'somaticVariantsCount': {}, 'unknownVariantsCount': {}, 'totalSampleCount': 0, 'sampleCountByGene': {}}
+# Download files first
+# There will be internal MSK-IMAPCT, GENIE v15 public cohort, and TCGA Pan-Cancer Atlas (32 cohorts)
+# Each one contains xxx_mutations.txt and xxx_clinical_samples.txt
+# TCGA Pan-Cancer data can be downloaded by running download_files.py. Files are stored in /files/tcga
+# MSK-IMAPCT data can be downloaded from https://github.mskcc.org/cdsi/msk-impact.git in msk_solid_heme folder. Files are stored in /files/mskimpact
+# GENIE data can be downloaded from https://www.synapse.org/#!Synapse:syn53210170. Files are stored in /files/genie
 
-# Read the JSON file
+class StudyInfo:
+    def __init__(self, panel_name: str, panel_list: List[str]):
+        self.panel_name = panel_name
+        self.panel_list = panel_list
+
+def find_file_pairs(folder_path: str):
+    # Get all files in the directory
+    files = os.listdir(folder_path)
+    mutation_files = [f for f in files if f.endswith('_mutations.txt')]
+    clinical_files = [f for f in files if f.endswith('_clinical_samples.txt')]
+
+    # Find pairs of files that have the same prefix
+    pairs = []
+    for m_file in mutation_files:
+        prefix = m_file.replace('_mutations.txt', '')
+        for c_file in clinical_files:
+            if c_file.startswith(prefix):
+                pairs.append((m_file, c_file))
+
+    return pairs
+
 with open('../VUEs.json', 'r') as f:
     data = json.load(f)
 
-# Create a set from the JSON data
-jsonSet = {vue['genomicLocation'] for vueSet in data for vue in vueSet['revisedProteinEffects']}
+def updateCounts(mutation_file: str, clinical_file: str, study_id: str, study_info: StudyInfo, multiple_study: bool, first_study: bool):
+    jsonSet = {vue['genomicLocation'] for vueSet in data for vue in vueSet['revisedProteinEffects']}
 
-# Define a function to update the counts
-def updateCounts(files, counts):
-    # Iterate over each file
-    for file in files:
-        # Read each TXT file into a DataFrame
-        df = pd.read_csv(file, sep="\t", usecols=['Hugo_Symbol', 'Chromosome', 'Start_Position', 'End_Position', 'Reference_Allele', 'Tumor_Seq_Allele1', 'Tumor_Seq_Allele2', 'Mutation_Status', 'Tumor_Sample_Barcode'])
-        
-        print("Counting from " + file)
-        # Update the total sample count
-        counts['totalSampleCount'] += df['Tumor_Sample_Barcode'].nunique()
+    counts =  {'germlineVariantsCount': {}, 'somaticVariantsCount': {}, 'unknownVariantsCount': {}, 'totalPatientCount': 0, 'patientCountByGene': {}}
+    mutationPatientsId = set()
+    checkedPatientId = set()
+    # Read clinical sample data
+    clinical_sample_df = pd.read_csv(clinical_file, sep='\t')
 
-        # Group the DataFrame by 'Hugo_Symbol' and count unique 'Tumor_Sample_Barcode' values
-        sampleCountByGene = df.groupby('Hugo_Symbol')['Tumor_Sample_Barcode'].nunique()
-        
-        # Update the sampleCountByGene map
-        for gene, count in sampleCountByGene.iteritems():
-            counts['sampleCountByGene'][gene] = counts['sampleCountByGene'].get(gene, 0) + count
+    # Filter data by gene panel
+    if study_info is not None:
+        filtered_clinical_sample_df = clinical_sample_df[clinical_sample_df[study_info.panel_name].isin(study_info.panel_list)]
+    else:
+        filtered_clinical_sample_df = clinical_sample_df
 
-        # Iterate over the DataFrame rows
-        for index, row in df.iterrows():
-            # Generate the genomicLocationString
-            genomicLocationString = f"{row['Chromosome']},{row['Start_Position']},{row['End_Position']},{row['Reference_Allele']},{row['Tumor_Seq_Allele2']}"
-            
-            # Check if the genomicLocationString is in the jsonSet
-            if genomicLocationString in jsonSet:
-                # If it is, increment the count in the corresponding variantsCount map
+    # Count unique PATIENT_ID
+    counts['totalPatientCount'] = len(filtered_clinical_sample_df['PATIENT_ID'].unique())
+    sample_to_patient_map = dict(zip(filtered_clinical_sample_df['SAMPLE_ID'], filtered_clinical_sample_df['PATIENT_ID']))
+    mutations_df = pd.read_csv(mutation_file, sep='\t', usecols=['Hugo_Symbol', 'Chromosome', 'Start_Position', 'End_Position', 'Reference_Allele', 'Tumor_Seq_Allele1', 'Tumor_Seq_Allele2', 'Mutation_Status', 'Tumor_Sample_Barcode'])
+
+    filtered_mutations_df = mutations_df[mutations_df['Tumor_Sample_Barcode'].isin(sample_to_patient_map.keys())]
+
+    # Count sample number by gene
+    # Group the DataFrame by 'Hugo_Symbol' and count unique 'Tumor_Sample_Barcode' values
+    for gene, group in filtered_mutations_df.groupby('Hugo_Symbol'):
+        for index, row in group.iterrows():
+            patientId = sample_to_patient_map.get(row['Tumor_Sample_Barcode'])
+            if patientId and patientId not in checkedPatientId:
+                counts['patientCountByGene'][gene] = counts['patientCountByGene'].get(gene, 0) + 1
+                checkedPatientId.add(patientId)
+
+    for index, row in filtered_mutations_df.iterrows():
+        genomicLocationString = f"{row['Chromosome']},{row['Start_Position']},{row['End_Position']},{row['Reference_Allele']},{row['Tumor_Seq_Allele2']}"
+        if genomicLocationString in jsonSet:
+            if row['Tumor_Sample_Barcode'] in sample_to_patient_map and sample_to_patient_map[row['Tumor_Sample_Barcode']] not in mutationPatientsId:
+                mutationPatientsId.add(sample_to_patient_map[row['Tumor_Sample_Barcode']])
                 if row['Mutation_Status'].lower() == 'germline':
                     counts['germlineVariantsCount'][genomicLocationString] = counts['germlineVariantsCount'].get(genomicLocationString, 0) + 1
                 elif row['Mutation_Status'].lower() == 'somatic':
@@ -50,29 +78,50 @@ def updateCounts(files, counts):
                 else:
                     counts['unknownVariantsCount'][genomicLocationString] = counts['unknownVariantsCount'].get(genomicLocationString, 0) + 1
 
-# Update the counts for the mskimpact and tcga files
-updateCounts(mskimpact_files, mskimpactCounts)
-updateCounts(tcga_files, tcgaCounts)
+    # Add the count numbers to the corresponding JSON objects
+    for vueSet in data:
+        for vue in vueSet['revisedProteinEffects']:
+            if 'counts' in vue:
+                if multiple_study and study_id in vue['counts'] and not first_study:
+                    vue['counts'][study_id] = { 
+                            "germlineVariantsCount": counts["germlineVariantsCount"].get(vue['genomicLocation'], 0) + vue['counts'][study_id]['germlineVariantsCount'],
+                            "somaticVariantsCount": counts["somaticVariantsCount"].get(vue['genomicLocation'], 0) + vue['counts'][study_id]['somaticVariantsCount'],
+                            "unknownVariantsCount": counts["unknownVariantsCount"].get(vue['genomicLocation'], 0) + vue['counts'][study_id]['unknownVariantsCount'],
+                            "totalPatientCount": counts.get("totalPatientCount") + vue['counts'][study_id]['totalPatientCount'],
+                            "genePatientCount": counts['patientCountByGene'].get(vueSet['hugoGeneSymbol'], 0) + vue['counts'][study_id]['genePatientCount']
+                        }
+                else:
+                    vue['counts'][study_id] = { 
+                            "germlineVariantsCount": counts["germlineVariantsCount"].get(vue['genomicLocation'], 0),
+                            "somaticVariantsCount": counts["somaticVariantsCount"].get(vue['genomicLocation'], 0),
+                            "unknownVariantsCount": counts["unknownVariantsCount"].get(vue['genomicLocation'], 0),
+                            "totalPatientCount": counts.get("totalPatientCount"),
+                            "genePatientCount": counts['patientCountByGene'].get(vueSet['hugoGeneSymbol'], 0)
+                        }
+            else:
+                vue['counts']= { 
+                    study_id: {
+                        "germlineVariantsCount": counts["germlineVariantsCount"].get(vue['genomicLocation'], 0),
+                        "somaticVariantsCount": counts["somaticVariantsCount"].get(vue['genomicLocation'], 0),
+                        "unknownVariantsCount": counts["unknownVariantsCount"].get(vue['genomicLocation'], 0),
+                        "totalPatientCount": counts.get("totalPatientCount"),
+                        "genePatientCount": counts['patientCountByGene'].get(vueSet['hugoGeneSymbol'], 0)
+                }}
 
-# Add the count numbers to the corresponding JSON objects
-for item in data:
-    for vue in item['revisedProteinEffects']:
-        vue['counts'] = {
-            'mskimpact': {
-                "germlineVariantsCount": mskimpactCounts["germlineVariantsCount"].get(vue['genomicLocation'], 0),
-                "somaticVariantsCount": mskimpactCounts["somaticVariantsCount"].get(vue['genomicLocation'], 0),
-                "unknownVariantsCount": mskimpactCounts["unknownVariantsCount"].get(vue['genomicLocation'], 0),
-                "totalSampleCount": mskimpactCounts.get("totalSampleCount"),
-                "geneSampleCount": mskimpactCounts['sampleCountByGene'].get(item['hugoGeneSymbol'], 0)
-            },
-            'tcga': {
-                "germlineVariantsCount": tcgaCounts["germlineVariantsCount"].get(vue['genomicLocation'], 0),
-                "somaticVariantsCount": tcgaCounts["somaticVariantsCount"].get(vue['genomicLocation'], 0),
-                "unknownVariantsCount": tcgaCounts["unknownVariantsCount"].get(vue['genomicLocation'], 0),
-                "totalSampleCount": tcgaCounts.get("totalSampleCount"),
-                "geneSampleCount": tcgaCounts['sampleCountByGene'].get(item['hugoGeneSymbol'], 0)
-            }
-        }
+# Update mskimpact counts
+study_info_mskimpact = StudyInfo('GENE_PANEL', ["IMPACT341", "IMPACT410", "IMPACT468", "IMPACT505"])
+updateCounts('./files/mskimpact/mskimpact_data_mutations_extended.txt', './files/mskimpact/mskimpact_data_clinical_sample.txt', 'mskimpact', study_info_mskimpact, False, False)
+# Update genie counts
+study_info_genie = StudyInfo('SEQ_ASSAY_ID', ["MSK-IMPACT341","MSK-IMPACT410", "MSK-IMPACT468", "MSK-IMPACT505"])
+updateCounts('./files/genie/genie_data_mutations_extended.txt', './files/genie/genie_data_clinical_sample.txt', 'genie', study_info_genie, False, False)
+# Update tcga counts
+tcga_folder = './files/tcga'
+tcga_file_pairs = find_file_pairs(tcga_folder)
+for index, pair in enumerate(tcga_file_pairs):
+    mutation_file_name, clinical_file_name = pair
+    mutation_file_path = tcga_folder + '/' + mutation_file_name
+    clinical_file_path = tcga_folder + '/' + clinical_file_name
+    updateCounts(mutation_file_path, clinical_file_path, 'tcga', None, True, index == 0)
 
 # Write the updated JSON data back to the file
 with open('../VUEs.json', 'w') as f:


### PR DESCRIPTION
Update variant count and the scripts:
- [x] Add GENIE v15 public cohort count
- [x] Count variants per patient
- [x] Count the total patient number from clinical_samples.txt, not just the mutations.txt
- [x] For MSK-IMPACT, only count from GENE_PANEL: IMPACT468, IMPACT505, IMPACT410, IMPACT341 (exclude ACCESS and HEME)
- [x] For GENIE, only count from SEQ_ASSAY_ID: MSK-IMPACT341,MSK-IMPACT410, MSK-IMPACT505, MSK-IMPACT468