### PR TITLE
Oncokb germline project add vue TP53, MLH1, BRIP1, ATM

### DIFF
--- a/VUEs.json
+++ b/VUEs.json
@@ -15,9 +15,13 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.K550_K558del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 15507676,
-                "referenceText": "Corless et al., 2004",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "15507676",
+                        "referenceText": "Corless et al., 2004"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -57,9 +61,13 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.K550_K558del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 15507676,
-                "referenceText": "Corless et al., 2004",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "15507676",
+                        "referenceText": "Corless et al., 2004"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -99,9 +107,13 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.K550_K558del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 15507676,
-                "referenceText": "Corless et al., 2004",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "15507676",
+                        "referenceText": "Corless et al., 2004"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -151,9 +163,13 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.G279Ffs*10",
                 "revisedVariantClassification": "Splice_Exon_Extension_Out_Of_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -203,9 +219,13 @@
                 "vepPredictedVariantClassification": "Silent",
                 "revisedProteinEffect": "p.D311Gfs*23",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
-                "pubmedId": 33681728,
-                "referenceText": "Niersch et al., 2021",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "33681728",
+                        "referenceText": "Niersch et al., 2021"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -255,9 +275,13 @@
                 "vepPredictedVariantClassification": "Missense_Mutation",
                 "revisedProteinEffect": "p.X61",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
-                "pubmedId": 35236983,
-                "referenceText": "Kobayashi et al., 2022",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "35236983",
+                        "referenceText": "Kobayashi et al., 2022"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -307,9 +331,13 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.Q28_D81del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -343,15 +371,19 @@
             },
             {
                 "variant": "3:g.41266012_41266312del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41266012,41266312,TATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTGCCTTACTGAAAGTCAGAATGCAGTTTTGAGAACTAAAAAGTTAGTG,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X5_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -385,15 +417,19 @@
             },
             {
                 "variant": "3:g.41266038_41266264del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41266038,41266264,TGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCAT,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X13_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.M12_D81del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -427,15 +463,19 @@
             },
             {
                 "variant": "3:g.41265709_41266219del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41265709,41266219,TCCTCCTAATGGCTTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAG,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X5_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_Q72del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -469,15 +509,19 @@
             },
             {
                 "variant": "3:g.41266090_41266253del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41266090,41266253,TTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTA,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X30_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.S29_D81del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -511,15 +555,19 @@
             },
             {
                 "variant": "3:g.41265579_41266277del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41265579,41266277,GTCATTAAATCTTTAGTTACTGAATTGGGGCTCTGCTTCGTTGCCATTAAGCCAGTCTGGCTGAGATCCCCCTGCTTTCCTCTCTCCCTGCTTACTTGTCAGGCTACCTTTTGCTCCATTTTCTGCTCACTCCTCCTAATGGCTTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTGCCTTACTGAAA,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X5_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -553,15 +601,19 @@
             },
             {
                 "variant": "3:g.41265722_41266253del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41265722,41266253,TTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTA,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X5_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -595,15 +647,19 @@
             },
             {
                 "variant": "3:g.41266029_41266287del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41266029,41266287,AGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTGCCTTACTGAAAGTCAGAATGC,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X10_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.E9_D81del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -637,15 +693,19 @@
             },
             {
                 "variant": "3:g.41266028_41266420del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41266028,41266420,GAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTGCCTTACTGAAAGTCAGAATGCAGTTTTGAGAACTAAAAAGTTAGTGTATAATAGTTTAAATAAAATGTTGTGGTGAAGAAAAGAGAGTAATAGCAATGTCACTTTTACCATTTAGGATAGCAAATACTTAGGTAAATGCTGAACTGTGGATAGT,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X10_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.E9_D81del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -679,15 +739,19 @@
             },
             {
                 "variant": "3:g.41266016_41266403del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41266016,41266403,GCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTGCCTTACTGAAAGTCAGAATGCAGTTTTGAGAACTAAAAAGTTAGTGTATAATAGTTTAAATAAAATGTTGTGGTGAAGAAAAGAGAGTAATAGCAATGTCACTTTTACCATTTAGGATAGCAAATACTTAGGTAAAT,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X6_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -721,15 +785,19 @@
             },
             {
                 "variant": "3:g.41265975_41266211del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41265975,41266211,CATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGAT,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X5_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_G69del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -763,15 +831,19 @@
             },
             {
                 "variant": "3:g.41265908_41266236del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41265908,41266236,TTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACA,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X5_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_Q79del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -805,15 +877,19 @@
             },
             {
                 "variant": "3:g.41266013_41266355del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41266013,41266355,ATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTGCCTTACTGAAAGTCAGAATGCAGTTTTGAGAACTAAAAAGTTAGTGTATAATAGTTTAAATAAAATGTTGTGGTGAAGAAAAGAGAGTA,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X5_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -847,15 +923,19 @@
             },
             {
                 "variant": "3:g.41265897_41266218del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41265897,41266218,GTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCA,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X5_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_Q72del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -889,15 +969,19 @@
             },
             {
                 "variant": "3:g.41266002_41266029del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41266002,41266029,GTTTCGTATTTATAGCTGATTTGATGGA,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X5_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_E9del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -931,15 +1015,19 @@
             },
             {
                 "variant": "3:g.41265562_41266260del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41265562,41266260,GGCTACTCAAGGTTTGTGTCATTAAATCTTTAGTTACTGAATTGGGGCTCTGCTTCGTTGCCATTAAGCCAGTCTGGCTGAGATCCCCCTGCTTTCCTCTCTCCCTGCTTACTTGTCAGGCTACCTTTTGCTCCATTTTCTGCTCACTCCTCCTAATGGCTTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTT,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X1_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A2_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -973,15 +1061,19 @@
             },
             {
                 "variant": "3:g.41265568_41266266del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41265568,41266266,TCAAGGTTTGTGTCATTAAATCTTTAGTTACTGAATTGGGGCTCTGCTTCGTTGCCATTAAGCCAGTCTGGCTGAGATCCCCCTGCTTTCCTCTCTCCCTGCTTACTTGTCAGGCTACCTTTTGCTCCATTTTCTGCTCACTCCTCCTAATGGCTTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTG,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X3_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.Q4_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1015,15 +1107,19 @@
             },
             {
                 "variant": "3:g.41265571_41266206del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41265571,4126620,AGGTTTGTGTCATTAAATCTTTAGTTACTGAATTGGGGCTCTGCTTCGTTGCCATTAAGCCAGTCTGGCTGAGATCCCCCTGCTTTCCTCTCTCCCTGCTTACTTGTCAGGCTACCTTTTGCTCCATTTTCTGCTCACTCCTCCTAATGGCTTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACA,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X4_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_Q68del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1057,15 +1153,19 @@
             },
             {
                 "variant": "3:g.41265648_41266493del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41265648,41266493,CCCTGCTTTCCTCTCTCCCTGCTTACTTGTCAGGCTACCTTTTGCTCCATTTTCTGCTCACTCCTCCTAATGGCTTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTGCCTTACTGAAAGTCAGAATGCAGTTTTGAGAACTAAAAAGTTAGTGTATAATAGTTTAAATAAAATGTTGTGGTGAAGAAAAGAGAGTAATAGCAATGTCACTTTTACCATTTAGGATAGCAAATACTTAGGTAAATGCTGAACTGTGGATAGTGAGTGTTGAATTAACCTTTTCCAGATATTGATGGACAGTATGCAATGACTCGAGCTCAGAGGGTACGAGCTGC,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X5_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_A97del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1099,15 +1199,19 @@
             },
             {
                 "variant": "3:g.41265674_41266212del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41265674,41266212,TTGTCAGGCTACCTTTTGCTCCATTTTCTGCTCACTCCTCCTAATGGCTTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATT,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X5_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_F70del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1141,15 +1245,19 @@
             },
             {
                 "variant": "3:g.41265990_41266204del",
-                "transcriptId": "ENST00000349496",
                 "genomicLocation": "3,41265990,41266204,AATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAA,-",
+                "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X5_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_Q68del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
-                "pubmedId": 29316426,
-                "referenceText": "Yaeger et al., 2018",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1193,15 +1301,19 @@
         "revisedProteinEffects": [
             {
                 "variant": "7:g.116411926_116412083del",
-                "transcriptId": "ENST00000397752",
                 "genomicLocation": "7,116411926,116412083,TACGATGCAAGAGTACACACTCCTCATTTGGATAGGCTTGTAAGTGCCCGAAGTGTAAGCCCAACTACAGAAATGGTTTCAAATGAATCTGTAGACTACCGAGCTACTTTTCCAGAAGGTATATTTCAGTTTATTGTTCTGAGAAATACCTATACATA,-",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.X972_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 27343443,
-                "referenceText": "Schrock et al., 2014",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "27343443",
+                        "referenceText": "Schrock et al., 2014"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1235,15 +1347,19 @@
             },
             {
                 "variant": "7:g.116411770_116412349del",
-                "transcriptId": "ENST00000397752",
                 "genomicLocation": "7,116411770,116412349,AGATTGTCGTCGATTCTTGTGTGCTGTCTTATATGTAGTCCATAAAACCCATGAGTTCTGGGCACTGGGTCAAAGTCTCCTGGGGCCCATGATAGCCGTCTTTAACAAGCTCTTTCTTTCTCTCTGTTTTAAGATCTGGGCAGTGAATTAGTTCGCTACGATGCAAGAGTACACACTCCTCATTTGGATAGGCTTGTAAGTGCCCGAAGTGTAAGCCCAACTACAGAAATGGTTTCAAATGAATCTGTAGACTACCGAGCTACTTTTCCAGAAGGTATATTTCAGTTTATTGTTCTGAGAAATACCTATACATATACCTCAGTGGGTTGTGACATTGTTGTTTATTTTTGGTTTTGCATTTATATTTTTATAAAAACCTAAAGGAAGTATTTACCTCTGCCAAGTAAGTATTTGACACAAAATTACATGGCTCTTAATTTTAAAAGAACCCATGTATATATTACATTATGATTTTAGAGTCCATAAGCTCTCATTTCACAAAAAGGTTAATTTGAGCAAAAGTAATTTGTTTATCATCTAAGTGCAATAGTAAGAAATTGCGAAGCTCTCTTTTACAATC,-",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.X963_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 27343443,
-                "referenceText": "Schrock et al., 2014",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "27343443",
+                        "referenceText": "Schrock et al., 2014"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1277,15 +1393,19 @@
             },
             {
                 "variant": "7:g.116411818_116412557del",
-                "transcriptId": "ENST00000397752",
                 "genomicLocation": "7,116411818,116412557,CCATGAGTTCTGGGCACTGGGTCAAAGTCTCCTGGGGCCCATGATAGCCGTCTTTAACAAGCTCTTTCTTTCTCTCTGTTTTAAGATCTGGGCAGTGAATTAGTTCGCTACGATGCAAGAGTACACACTCCTCATTTGGATAGGCTTGTAAGTGCCCGAAGTGTAAGCCCAACTACAGAAATGGTTTCAAATGAATCTGTAGACTACCGAGCTACTTTTCCAGAAGGTATATTTCAGTTTATTGTTCTGAGAAATACCTATACATATACCTCAGTGGGTTGTGACATTGTTGTTTATTTTTGGTTTTGCATTTATATTTTTATAAAAACCTAAAGGAAGTATTTACCTCTGCCAAGTAAGTATTTGACACAAAATTACATGGCTCTTAATTTTAAAAGAACCCATGTATATATTACATTATGATTTTAGAGTCCATAAGCTCTCATTTCACAAAAAGGTTAATTTGAGCAAAAGTAATTTGTTTATCATCTAAGTGCAATAGTAAGAAATTGCGAAGCTCTCTTTTACAATCCAGGAAGAGTTAAGTTACAAAATATACTTATTTAAATGTAAGTTGGAACTGCTACATTTTTTACCTGTTGAAGCCCAAACATTGAAATTATACTGTTAGTAATTCTTCGAAGTGTTTTCAATGAACTGTTAGTACACAGCCTTTTTCCCACCATATTCTAGGACTTGAATGTATTTTGAGACTTAGCCAAGGAAAACCTTCAATTATG,-",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.X963_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 27343443,
-                "referenceText": "Schrock et al., 2014",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "27343443",
+                        "referenceText": "Schrock et al., 2014"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1320,14 +1440,18 @@
             {
                 "variant": "7:g.116411874_116411897del",
                 "genomicLocation": "7,116411874,116411897,ACAAGCTCTTTCTTTCTCTCTGTT,-",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.X963_splice",
                 "vepPredictedVariantClassification": "Splice_Region",
-                "transcriptId": "ENST00000397752",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 0,
-                "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1362,14 +1486,18 @@
             {
                 "variant": "7:g.116411881_116411897del",
                 "genomicLocation": "7,116411881,116411897,CTTTCTTTCTCTCTGTT,-",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.X963_splice",
                 "vepPredictedVariantClassification": "Splice_Region",
-                "transcriptId": "ENST00000397752",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 0,
-                "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1404,14 +1532,18 @@
             {
                 "variant": "7:g.116411881_116411937del",
                 "genomicLocation": "7,116411881,116411937,CTTTCTTTCTCTCTGTTTTAAGATCTGGGCAGTGAATTAGTTCGCTACGATGCAAGA,-",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.X963_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000397752",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 0,
-                "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1446,14 +1578,18 @@
             {
                 "variant": "7:g.116411860_116411888del",
                 "genomicLocation": "7,116411860,116411888,GATAGCCGTCTTTAACAAGCTCTTTCTTT,-",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.*963*",
                 "vepPredictedVariantClassification": "Intron",
-                "transcriptId": "ENST00000397752",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 0,
-                "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1488,14 +1624,18 @@
             {
                 "variant": "7:g.116411879_116411896del",
                 "genomicLocation": "7,116411879,116411896,CTCTTTCTTTCTCTCTGT,-",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.X963_splice",
                 "vepPredictedVariantClassification": "Splice_Region",
-                "transcriptId": "ENST00000397752",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 0,
-                "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1530,14 +1670,18 @@
             {
                 "variant": "7:g.116412046A>G",
                 "genomicLocation": "7,116412046,116412046,A,G",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.X1010_splice",
                 "vepPredictedVariantClassification": "Splice_Region",
-                "transcriptId": "ENST00000397752",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 0,
-                "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1572,14 +1716,18 @@
             {
                 "variant": "7:g.116411879_116411897del",
                 "genomicLocation": "7,116411879,116411897,CTCTTTCTTTCTCTCTGTT,-",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.X963_splice",
                 "vepPredictedVariantClassification": "Splice_Region",
-                "transcriptId": "ENST00000397752",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 0,
-                "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1614,14 +1762,18 @@
             {
                 "variant": "7:g.116411887_116411906del",
                 "genomicLocation": "7,116411887,116411906,TTCTCTCTGTTTTAAGATCT,-",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.X963_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000397752",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 0,
-                "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1656,14 +1808,18 @@
             {
                 "variant": "7:g.116412043G>A",
                 "genomicLocation": "7,116412043,116412043,G,A",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.D1010N",
                 "vepPredictedVariantClassification": "Missense_Mutation",
-                "transcriptId": "ENST00000397752",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 0,
-                "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1698,14 +1854,18 @@
             {
                 "variant": "7:g.116411885_116411897del",
                 "genomicLocation": "7,116411885,116411897,CTTTCTCTCTGTT,-",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.X963_splice",
                 "vepPredictedVariantClassification": "Splice_Region",
-                "transcriptId": "ENST00000397752",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 0,
-                "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1740,14 +1900,18 @@
             {
                 "variant": "7:g.116412041_116412044del",
                 "genomicLocation": "7,116412041,116412044,AAGG,-",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.X1009_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000397752",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 0,
-                "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1782,14 +1946,18 @@
             {
                 "variant": "7:g.116411881_116411895del",
                 "genomicLocation": "7,116411881,116411895,CTTTCTTTCTCTCTG,-",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.X963_splice",
                 "vepPredictedVariantClassification": "Splice_Region",
-                "transcriptId": "ENST00000397752",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 0,
-                "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1824,14 +1992,18 @@
             {
                 "variant": "7:g.116411867_116411882del",
                 "genomicLocation": "7,116411867,116411882,GTCTTTAACAAGCTCT,-",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.*963*",
                 "vepPredictedVariantClassification": "Intron",
-                "transcriptId": "ENST00000397752",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 0,
-                "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1866,14 +2038,18 @@
             {
                 "variant": "7:g.116412044G>A",
                 "genomicLocation": "7,116412044,116412044,G,A",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.X1010_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000397752",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 0,
-                "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1908,14 +2084,18 @@
             {
                 "variant": "7:g.116411876_116411896del",
                 "genomicLocation": "7,116411876,116411896,AAGCTCTTTCTTTCTCTCTGT,-",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.X963_splice",
                 "vepPredictedVariantClassification": "Splice_Region",
-                "transcriptId": "ENST00000397752",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 0,
-                "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -1950,14 +2130,18 @@
             {
                 "variant": "7:g.116411867_116411890del",
                 "genomicLocation": "7,116411867,116411890,GTCTTTAACAAGCTCTTTCTTTCT,-",
+                "transcriptId": "ENST00000397752",
                 "vepPredictedProteinEffect": "p.*963*",
                 "vepPredictedVariantClassification": "Intron",
-                "transcriptId": "ENST00000397752",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 0,
-                "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2002,14 +2186,18 @@
             {
                 "variant": "5:g.67589663G>C",
                 "genomicLocation": "5,67589663,67589663,G,C",
+                "transcriptId": "ENST00000521381",
                 "vepPredictedProteinEffect": "p.X475_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000521381",
                 "revisedProteinEffect": "p.D434_E476del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "pubmedId": 25488983,
-                "referenceText": "Lucas et al., 2014",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "25488983",
+                        "referenceText": "Lucas et al., 2014"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2054,14 +2242,18 @@
             {
                 "variant": "13:g.28608217_28608218insCCAAACTCTAAATTTTCTCTTGGAAACTCCCATTTGAGATCATATTCATATTCTCTG",
                 "genomicLocation": "13,28608217,28608218,-,CCAAACTCTAAATTTTCTCTTGGAAACTCCCATTTGAGATCATATTCATATTCTCTG",
+                "transcriptId": "ENST00000241453",
                 "vepPredictedProteinEffect": "p.X594_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000241453",
                 "revisedProteinEffect": "p.E598_F612dup",
                 "revisedVariantClassification": "Splice_Exon_Extension_In_Frame",
-                "pubmedId": 31285539,
-                "referenceText": "Zhang et al., 2020",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31285539",
+                        "referenceText": "Zhang et al., 2020"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2101,20 +2293,23 @@
         "genomicLocationDescription": "Mutations at canonical splice sites predicted to alter splicing",
         "defaultEffect": "missense, splice",
         "comment": "Splice leads to exon skip, frameshift and inframe deletion",
-        "context": "",
+        "context": "In ataxia telangiectasia and familial prostate cancer, increase the risk of breast and pancreatic cancer",
         "revisedProteinEffects": [
             {
                 "variant": "11:g.108115753G>A",
                 "genomicLocation": "11,108115753,108115753,G,A",
+                "transcriptId": "ENST00000278616",
                 "vepPredictedProteinEffect": "p.G301S",
                 "vepPredictedVariantClassification": "Missense_Mutation",
-                "transcriptId": "ENST00000278616",
                 "revisedProteinEffect": "p.C222Qfs*2",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2144,20 +2339,29 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 797
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             },
             {
                 "variant": "11:g.108127067G>A",
                 "genomicLocation": "11,108127067,108127067,G,A",
+                "transcriptId": "ENST00000278616",
                 "vepPredictedProteinEffect": "p.X750_splice",
                 "vepPredictedVariantClassification": "Splice_Region",
-                "transcriptId": "ENST00000278616",
                 "revisedProteinEffect": "p.I709_K750del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
-                "confirmed": false,
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "9887333",
+                        "referenceText": "Sandoval et al., 1999"
+                    },
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "variantNote": "This heterozygous germline variant ATM c.2250G>A variant does not change the encoded amino acid of the ATM protein (p.Lys750=), however, it falls at the last base pair of exon 14 of ATM. This variant has been identified in <0.01% of Non-Finnish European chromosomes in the genome Aggregation Database (http://gnomad.broadinstitute.org). It has been reported in combination with another pathogenic variant in individuals and families with Ataxia-telangiectasia (PMID: 9463314, 10980530, 9887333, 10330348, 19691550). It has also been reported in the heterozygous state in a BRCA1/2 negative individual undergoing multigene panel testing (PMID:26270727). An experimental study showed that this variant affects splicing and leads to exon skipping of exon 14 (PMID: 9887333). This variant is classified as pathogenic. ATM truncating mutations may increase the risk of breast cancer and pancreatic cancer (PMID: 21787400; PMID: 22585167) and have been reported in families with familial prostate cancer (PMID: 24556621.). Ataxia-telangiectasia is an autosomal recessive condition characterized by progressive cerebellar ataxia, telangiectasias, immunodeficiency, and increased cancer risks and is caused by two mutations (one affecting each allele) in the ATM gene. If an ATM mutation carrier's partner is heterozygous for a pathogenic ATM mutation, there is a 25% risk that each child would be affected by ataxia-telangiectasia.",
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2187,20 +2391,24 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 797
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             },
             {
                 "variant": "11:g.108138071T>C",
                 "genomicLocation": "11,108138071,108138071,T,C",
+                "transcriptId": "ENST00000278616",
                 "vepPredictedProteinEffect": "p.X880_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000278616",
                 "revisedProteinEffect": "p.A823Vfs*5",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2230,20 +2438,24 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 797
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             },
             {
                 "variant": "11:g.108175400A>C",
                 "genomicLocation": "11,108175400,108175400,A,C",
+                "transcriptId": "ENST00000278616",
                 "vepPredictedProteinEffect": "p.X1833_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000278616",
                 "revisedProteinEffect": "p.V1833Ifs*63",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2273,20 +2485,24 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 797
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             },
             {
                 "variant": "11:g.108198370A>C",
                 "genomicLocation": "11,108198370,108198370,A,C",
+                "transcriptId": "ENST00000278616",
                 "vepPredictedProteinEffect": "p.X2326_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000278616",
                 "revisedProteinEffect": "p.N2326_K2363del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2316,20 +2532,24 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 797
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             },
             {
                 "variant": "11:g.108198484_108198522del",
                 "genomicLocation": "11,108198484,108198522,AGGTAAGATTTTTGGAGCAACCCTTAAGATAGTTACTTA,-",
+                "transcriptId": "ENST00000278616",
                 "vepPredictedProteinEffect": "p.X2363_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000278616",
                 "revisedProteinEffect": "p.N2326_K2363del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2359,20 +2579,24 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 797
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             },
             {
                 "variant": "11:g.108214099_108214103del",
                 "genomicLocation": "11,108214099,108214103,GTGAG,-",
+                "transcriptId": "ENST00000278616",
                 "vepPredictedProteinEffect": "p.X2806_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000278616",
                 "revisedProteinEffect": "p.V2757_M2806del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2402,20 +2626,24 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 797
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             },
             {
                 "variant": "11:g.108236051G>A",
                 "genomicLocation": "11,108236051,108236051,G,A",
+                "transcriptId": "ENST00000278616",
                 "vepPredictedProteinEffect": "p.X2996_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000278616",
                 "revisedProteinEffect": "p.S2996Rfs*5",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2445,7 +2673,112 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 797
                     }
-                }
+                },
+                "mutationOrigin": "germline"
+            },
+            {
+                "variant": "11:g.108202764G>A",
+                "genomicLocation": "11,108202764,108202764,G,A",
+                "transcriptId": "ENST00000278616",
+                "vepPredictedProteinEffect": "p.X2596_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.L2544_E2596del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "9792409",
+                        "referenceText": "Broeks et al., 1998"
+                    }
+                ],
+                "variantNote": "This heterozygous ATM c.7788G>A p.Glu2596Glu variant is a synonymous variant that occurs at the last nucleotide of exon 52 and does not alter the amino acid at this position. It has been identified in 0.002% of Non-Finnish European chromosomes by the Exome Aggregation Consortium (ExAC: http://exac.broadinstitute.org; dbSNP). This variant has been reported in two homozygous and one compound heterozygous individuals with ataxia-telangiectasia (PMID: 9792409 and 26693373). It has been demonstrated to cause altered splicing, leading to deletion of 53 amino acids in exon 52 (PMID: 9792409). This region includes part of the FAT domain, which has been suggested to be important for proper activity of the protein (PMID: 23532176, 25460276, 10782091, 27229179). In summary, based on the previous reports of this variant in individuals with ataxia-telangiectasia and its impact on the protein, this variant meets our criteria to be classified as pathogenic. ATM truncating mutations may increase the risk of breast cancer and pancreatic cancer (PMID: 21787400; PMID: 22585167) and have been reported in families with familial prostate cancer (PMID: 24556621.) Ataxia-telangiectasia is an autosomal recessive condition characterized by progressive cerebellar ataxia, telangiectasias, immunodeficiency, and increased cancer risks and is caused by two mutations (one affecting each allele) in the ATM gene. If an ATM mutation carrier's partner is heterozygous for a pathogenic ATM mutation, there is a 25% risk that each child would be affected by ataxia-telangiectasia.",
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1512
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 797
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1288
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 6
+                    }
+                },
+                "mutationOrigin": "germline"
+            },
+            {
+                "variant": "11:g.108151895G>A",
+                "genomicLocation": "11,108151895,108151895,G,A",
+                "transcriptId": "ENST00000278616",
+                "vepPredictedProteinEffect": "p.X1192_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.S1135_K1192",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "9887333",
+                        "referenceText": "Sandoval et al., 1999"
+                    },
+                    {
+                        "pubmedId": "16941484",
+                        "referenceText": "Cavalieri et al., 2006"
+                    },
+                    {
+                        "pubmedId": "21965147",
+                        "referenceText": "Demuth et al., 2011"
+                    }
+                ],
+                "variantNote": "This heterozygous ATM c.3576G>A variant is a synonymous alteration that does not change a Lysine to another amino acid at codon 1192 (p.Lys1192=). This variant occurs in the last nucleotide of an exon and leads to aberrant splicing leading to exon skipping according to in-vitro RNA studies (PMID: 9887333, 16941484, 21965147). This variant has been identified in 4/113572 of Non-Finnish European chromosomes by the Genome Aggregation Database (http://gnomad.broadinstitute.org/;), and has been reported in multiple individuals with ataxia telangiectasia in heterozygous (in-trans with another pathogenic ATM variant) or homozygous states (PMID: 30819809, 8845835, 9443866, 9792409, 9887333, 10330348, 12552559, 16941484, 17124347). Furthermore, this variant has been detected in patients with breast, thyroid or ampullary cancers (PMID: 27599564, 30620386, 31300551). In summary, based on the previous reports of this variant in individuals with ATM associated disease and in-vitro functional studies, this variant is classified as pathogenic. ATM truncating mutations may increase the risk of breast cancer and pancreatic cancer (PMID: 21787400; PMID: 22585167) and have been reported in families with familial prostate cancer (PMID: 24556621.) Ataxia-telangiectasia is an autosomal recessive condition characterized by progressive cerebellar ataxia, telangiectasias, immunodeficiency, and increased cancer risks and is caused by two mutations (one affecting each allele) in the ATM gene. If an ATM mutation carrier's partner is heterozygous for a pathogenic ATM mutation, there is a 25% risk that each child would be affected by ataxia-telangiectasia.",
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1512
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 797
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1288
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 6
+                    }
+                },
+                "mutationOrigin": "germline"
             }
         ]
     },
@@ -2460,15 +2793,18 @@
             {
                 "variant": "17:g.41197820C>T",
                 "genomicLocation": "17,41197820,41197820,C,T",
+                "transcriptId": "ENST00000357654",
                 "vepPredictedProteinEffect": "p.X1823_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000357654",
                 "revisedProteinEffect": "p.A1844Dfs*2",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2498,20 +2834,24 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 330
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             },
             {
                 "variant": "17:g.41228505C>A",
                 "genomicLocation": "17,41228505,41228505,C,A",
+                "transcriptId": "ENST00000357654",
                 "vepPredictedProteinEffect": "p.R1495M",
                 "vepPredictedVariantClassification": "Missense_Mutation",
-                "transcriptId": "ENST00000357654",
                 "revisedProteinEffect": "p.A1453Gfs*9",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2541,7 +2881,8 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 330
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             }
         ]
     },
@@ -2556,15 +2897,18 @@
             {
                 "variant": "13:g.32900634A>G",
                 "genomicLocation": "13,32900634,32900634,A,G",
+                "transcriptId": "ENST00000380152",
                 "vepPredictedProteinEffect": "p.X173_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000380152",
                 "revisedProteinEffect": "p.G173Sfs*17",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2594,20 +2938,24 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 221
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             },
             {
                 "variant": "13:g.32931878G>A",
                 "genomicLocation": "13,32931878,32931878,G,A",
+                "transcriptId": "ENST00000380152",
                 "vepPredictedProteinEffect": "p.X2540_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000380152",
                 "revisedProteinEffect": "p.L2540Qfs*10",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2637,20 +2985,24 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 221
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             },
             {
                 "variant": "13:g.32954050G>A",
                 "genomicLocation": "13,32954050,32954050,G,A",
+                "transcriptId": "ENST00000380152",
                 "vepPredictedProteinEffect": "p.X3039_splice",
                 "vepPredictedVariantClassification": "Splice_Region",
-                "transcriptId": "ENST00000380152",
                 "revisedProteinEffect": "p.V2985Gfs*3",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2680,7 +3032,8 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 221
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             }
         ]
     },
@@ -2689,21 +3042,72 @@
         "transcriptId": "ENST00000259008",
         "genomicLocationDescription": "Mutations at canonical splice sites predicted to alter splicing",
         "defaultEffect": "splice",
-        "comment": "Skip exon 2, loss of first ATG",
-        "context": "",
+        "comment": "Skip exon 5",
+        "context": "Reported in individuals with breast and ovarian cancers",
         "revisedProteinEffects": [
+            {
+                "variant": "17:g.59926490C>T",
+                "genomicLocation": "17,59926490,59926490,C,T",
+                "transcriptId": "ENST00000259008",
+                "vepPredictedProteinEffect": "p.X169_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.D127Dfs*1",
+                "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29368626",
+                        "referenceText": "Weber-Lassalle et al. 2018"
+                    }
+                ],
+                "variantNote": "This silent sequence change affects codon 169 of the BRIP1 mRNA and does not change the encoded amino acid sequence (p.Gln169=). This variant falls at the last nucleotide of BRIP1 exon 5. This variant is absent from large population databases (1000 Genomes, ESP, and gnomAD), and has been reported in the literature in individuals with breast and ovarian cancers (PMID: 29368626). An experimental study using patient RNA showed that this variant led to skipping of exon 5 and a prematurely truncated protein product (PMID: 29368626). In summary, although additional studies are required to fully establish its clinical significance, this BRIp1 c.507G>A p.Gln169= variant is classified as likely pathogenic. Heterozygous pathogenic variants in BRIP1 have been associated with an increased risk of ovarian cancer (PMID: 26315354, 2196457) and may increase the risk of breast cancer (PMID: 17033622). Biallelic mutations in BRIP1 have been associated with Fanconi Anemia, an autosomal recessive condition characterized by physical abnormalities, bone marrow failure, and increased risk of malignancy. If a BRIP1 mutation carrier's partner is heterozygous for a pathogenic BRIP1 mutation, there is a 25% risk that each child would be affected by Fanconi Anemia.",
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 195
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 163
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 156
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                },
+                "mutationOrigin": "germline"
+            },
             {
                 "variant": "17:g.59938807C>T",
                 "genomicLocation": "17,59938807,59938807,C,T",
+                "transcriptId": "ENST00000259008",
                 "vepPredictedProteinEffect": "p.X31_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000259008",
                 "revisedProteinEffect": "p.M1_S31del",
                 "revisedVariantClassification": "Splice_Exon_Skip_Non_Start",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2733,7 +3137,8 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 163
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             }
         ]
     },
@@ -2748,15 +3153,18 @@
             {
                 "variant": "16:g.68849663G>A",
                 "genomicLocation": "16,68849663,68849663,G,A",
+                "transcriptId": "ENST00000261769",
                 "vepPredictedProteinEffect": "p.X522_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000261769",
                 "revisedProteinEffect": "p.T523*",
                 "revisedVariantClassification": "Splice_Exon_Extension_Nonsense",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2786,20 +3194,24 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 170
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             },
             {
                 "variant": "16:g.68853328G>A",
                 "genomicLocation": "16,68853328,68853328,G,A",
+                "transcriptId": "ENST00000261769",
                 "vepPredictedProteinEffect": "p.G571S",
                 "vepPredictedVariantClassification": "Missense_Mutation",
-                "transcriptId": "ENST00000261769",
                 "revisedProteinEffect": "p.Y523Ffs*15",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2829,7 +3241,8 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 170
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             }
         ]
     },
@@ -2844,15 +3257,18 @@
             {
                 "variant": "22:g.29121230C>T",
                 "genomicLocation": "22,29121230,29121230,C,T",
+                "transcriptId": "ENST00000328354",
                 "vepPredictedProteinEffect": "p.X148_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000328354",
                 "revisedProteinEffect": "p.E149Ifs*5",
                 "revisedVariantClassification": "Splice_Exon_Extension_Out_Of_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2882,7 +3298,8 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 66
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             }
         ]
     },
@@ -2897,15 +3314,18 @@
             {
                 "variant": "16:g.23634452C>G",
                 "genomicLocation": "16,23634452,23634452,C,G",
+                "transcriptId": "ENST00000261584",
                 "vepPredictedProteinEffect": "p.X945_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000261584",
                 "revisedProteinEffect": "p.A946_G999del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2935,20 +3355,24 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 11
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             },
             {
                 "variant": "16:g.23640597C>A",
                 "genomicLocation": "16,23640597,23640597,C,A",
+                "transcriptId": "ENST00000261584",
                 "vepPredictedProteinEffect": "p.X839_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000261584",
                 "revisedProteinEffect": "p.T839_K862del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2978,7 +3402,8 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 11
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             }
         ]
     },
@@ -2993,15 +3418,18 @@
             {
                 "variant": "17:g.33428057T>A",
                 "genomicLocation": "17,33428057,33428057,T,A",
+                "transcriptId": "ENST00000590016",
                 "vepPredictedProteinEffect": "p.X302_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
-                "transcriptId": "ENST00000590016",
                 "revisedProteinEffect": "p.P322Vfs*5",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 31843900,
-                "referenceText": "Casadei et al., 2019",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -3031,30 +3459,90 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 6
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             }
         ]
     },
     {
         "hugoGeneSymbol": "MLH1",
         "transcriptId": "ENST00000231790",
-        "genomicLocationDescription": "3 bases upstream from the 3' end of exon 6 in MLH1",
+        "genomicLocationDescription": "Last nucleotide of exon 15",
         "defaultEffect": "splice",
-        "comment": "Created a new splice donor site at the end of exon 6 and frameshift occurred",
+        "comment": "Skipping of exon 15 and leads to an out-of-frame transcript and premature protein truncation",
         "context": "In Lynch syndrome colorectal cancer",
         "revisedProteinEffects": [
             {
+                "variant": "3:g.37083822G>A",
+                "genomicLocation": "3,37083822,37083822,G,A",
+                "transcriptId": "ENST00000231790",
+                "vepPredictedProteinEffect": "p.X577_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.S556Rfs*13",
+                "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "16341550",
+                        "referenceText": "Pagenstecher et al. 2006"
+                    },
+                    {
+                        "pubmedId": "18561205",
+                        "referenceText": "Tournier et al. 2008"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al. 2006"
+                    }
+                ],
+                "variantNote": "The heterozygous germline variant, MLH1 c.1731G>A (p.Ser577Ser), results in a silent mutation and occurs at the last nucleotide of exon 15. This variant is absent from the major population databases (1000G, ESP and gnomAD). It is a well known pathogenic variant that has been reported in several individuals and families with Lynch syndrome (PMID: 16341550, 15849733, 20223024, 26300997, 14635101, 16216036, 16395668, 19669161). Experimental studies using mRNA isolated from patients blood as well as a reporter minigene assay showed that this variant results in the skipping of exon 15 and leads to an out-of-frame transcript and premature protein truncation (PMID: 16341550, 18561205, 16451135). In summary, based on the previous reports of this variant in individuals with MLH1 associated cancers and its truncating effect on the protein, this variant meets our criteria to be classified as pathogenic. Lynch syndrome is an autosomal dominant condition that confers an increased risk for colorectal cancer and endometrial cancers as well as other cancers. There is a 50% chance that each child would inherit this variant from a carrier parent.",
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 9
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 6,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 53
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 8
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                },
+                "mutationOrigin": "germline"
+            },
+            {
                 "variant": "3:g.37050394C>T",
                 "genomicLocation": "3,37050394,37050394,C,T",
+                "transcriptId": "ENST00000231790",
                 "vepPredictedProteinEffect": "p.X181_splice",
                 "vepPredictedVariantClassification": "Splice_Region",
-                "transcriptId": "ENST00000231790",
                 "revisedProteinEffect": "p.G181Gfs*20",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
-                "mutationOrigin": "germline",
-                "pubmedId": 28334867,
-                "referenceText": "Yamaguchi et al., 2017",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "28334867",
+                        "referenceText": "Yamaguchi et al., 2017"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -3084,7 +3572,8 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 53
                     }
-                }
+                },
+                "mutationOrigin": "germline"
             }
         ]
     },
@@ -3099,14 +3588,18 @@
             {
                 "variant": "7:g.55248980_55248981insTCCAGGAAGCCT",
                 "genomicLocation": "7,55248980,55248981,-,TCCAGGAAGCCT",
+                "transcriptId": "ENST00000275493",
                 "vepPredictedProteinEffect": "p.X762_splice",
                 "vepPredictedVariantClassification": "Splice_Region",
-                "transcriptId": "ENST00000275493",
                 "revisedProteinEffect": "p.A763_Y764insFQEA",
                 "revisedVariantClassification": "Splice_Exon_Extension_In_Frame",
-                "pubmedId": 31715539,
-                "referenceText": "Sousa et al., 2020",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "31715539",
+                        "referenceText": "Sousa et al., 2020"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -3151,15 +3644,18 @@
             {
                 "variant": "17:g.7579307C>A",
                 "genomicLocation": "17,7579307,7579307,C,A",
+                "transcriptId": "ENST00000269305",
                 "vepPredictedProteinEffect": "p.X125_splice",
                 "vepPredictedVariantClassification": "Splice_Region",
-                "transcriptId": "ENST00000269305",
                 "revisedProteinEffect": "p.S33_T125del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
-                "mutationOrigin": "",
-                "pubmedId": 34505757,
-                "referenceText": "Chui et al., 2021",
                 "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "34505757",
+                        "referenceText": "Chui et al., 2021"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -3194,15 +3690,18 @@
             {
                 "variant": "17:g.7579307C>A",
                 "genomicLocation": "17,7579307,7579307,C,A",
+                "transcriptId": "ENST00000269305",
                 "vepPredictedProteinEffect": "p.X125_splice",
                 "vepPredictedVariantClassification": "Splice_Region",
-                "transcriptId": "ENST00000269305",
                 "revisedProteinEffect": "p.G59Vfs*23",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
-                "mutationOrigin": "",
-                "pubmedId": 34505757,
-                "referenceText": "Chui et al., 2021",
                 "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "34505757",
+                        "referenceText": "Chui et al., 2021"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -3233,6 +3732,54 @@
                         "genePatientCount": 283
                     }
                 }
+            },
+            {
+                "variant": "17:g.7579312C>A",
+                "genomicLocation": "17,7579312,7579312,C,A",
+                "transcriptId": "ENST00000269305",
+                "vepPredictedProteinEffect": "p.X125_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.S33_T125del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "11420676",
+                        "referenceText": "Varley et al. 2001"
+                    }
+                ],
+                "variantNote": "The heterozygous germline variant, TP53 c.375G>T (Thr125=), is located at the last nucleotide of exon 4 of the TP53 gene. This variant is absent from large population databases (1000 Genomes, ESP, and gnomAD). It has been reported in a family with Li Fraumeni syndrome (PMID: 11420676). In vitro studies and analysis of RNA from patient cells demonstrated that this variant leads to aberrant splicing (PMID: 11420676, 25730903). Two other variants at this position (c.375G>A and c.375G>C) have been reported in individuals and families with Li Fraumeni syndrome (PMID: 9242456, 10864200, 11420676, 24382691, 31105275). In summary, although additional studies are required to fully establish its clinical significance, based on its previous report in an individual with Li Fraumeni syndrome and its demonstrated impact on splicing, this c.375G>T (p.?) variant is classified as likely pathogenic. Li-Fraumeni syndrome (LFS) is an autosomal dominant cancer predisposition syndrome associated with an increased risk of tumors including soft tissue sarcoma, osteosarcoma, pre-menopausal breast cancer, brain tumors, adrenocortical carcinoma (ACC), and leukemias (http://www.ncbi.nlm.nih.gov/books/NBK1311/).",
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1217
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 124,
+                        "unknownVariantsCount": 2,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 283
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1109
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 25,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 1
+                    }
+                },
+                "mutationOrigin": "germline"
             }
         ]
     }


### PR DESCRIPTION
- New VUE:Add 5 new VUEs, and update 1 ATM VUE
- Add new field "variantNote"
- We start to have multiple publications for one VUE, add a new "references" object and list PubMed id and referenceText in pairs