### PR TITLE
Add F11, MLH1, MSH2 VUEs

### DIFF
--- a/VUEs.json
+++ b/VUEs.json
@@ -2361,7 +2361,6 @@
                         "referenceText": "Casadei et al., 2019"
                     }
                 ],
-                "variantNote": "This heterozygous germline variant ATM c.2250G>A variant does not change the encoded amino acid of the ATM protein (p.Lys750=), however, it falls at the last base pair of exon 14 of ATM. This variant has been identified in <0.01% of Non-Finnish European chromosomes in the genome Aggregation Database (http://gnomad.broadinstitute.org). It has been reported in combination with another pathogenic variant in individuals and families with Ataxia-telangiectasia (PMID: 9463314, 10980530, 9887333, 10330348, 19691550). It has also been reported in the heterozygous state in a BRCA1/2 negative individual undergoing multigene panel testing (PMID:26270727). An experimental study showed that this variant affects splicing and leads to exon skipping of exon 14 (PMID: 9887333). This variant is classified as pathogenic. ATM truncating mutations may increase the risk of breast cancer and pancreatic cancer (PMID: 21787400; PMID: 22585167) and have been reported in families with familial prostate cancer (PMID: 24556621.). Ataxia-telangiectasia is an autosomal recessive condition characterized by progressive cerebellar ataxia, telangiectasias, immunodeficiency, and increased cancer risks and is caused by two mutations (one affecting each allele) in the ATM gene. If an ATM mutation carrier's partner is heterozygous for a pathogenic ATM mutation, there is a 25% risk that each child would be affected by ataxia-telangiectasia.",
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2392,7 +2391,8 @@
                         "genePatientCount": 797
                     }
                 },
-                "mutationOrigin": "germline"
+                "mutationOrigin": "germline",
+                "variantNote": "This heterozygous germline variant ATM c.2250G>A variant does not change the encoded amino acid of the ATM protein (p.Lys750=), however, it falls at the last base pair of exon 14 of ATM. This variant has been identified in <0.01% of Non-Finnish European chromosomes in the genome Aggregation Database (http://gnomad.broadinstitute.org). It has been reported in combination with another pathogenic variant in individuals and families with Ataxia-telangiectasia (PMID: 9463314, 10980530, 9887333, 10330348, 19691550). It has also been reported in the heterozygous state in a BRCA1/2 negative individual undergoing multigene panel testing (PMID:26270727). An experimental study showed that this variant affects splicing and leads to exon skipping of exon 14 (PMID: 9887333). This variant is classified as pathogenic. ATM truncating mutations may increase the risk of breast cancer and pancreatic cancer (PMID: 21787400; PMID: 22585167) and have been reported in families with familial prostate cancer (PMID: 24556621.). Ataxia-telangiectasia is an autosomal recessive condition characterized by progressive cerebellar ataxia, telangiectasias, immunodeficiency, and increased cancer risks and is caused by two mutations (one affecting each allele) in the ATM gene. If an ATM mutation carrier's partner is heterozygous for a pathogenic ATM mutation, there is a 25% risk that each child would be affected by ataxia-telangiectasia."
             },
             {
                 "variant": "11:g.108138071T>C",
@@ -2691,7 +2691,6 @@
                         "referenceText": "Broeks et al., 1998"
                     }
                 ],
-                "variantNote": "This heterozygous ATM c.7788G>A p.Glu2596Glu variant is a synonymous variant that occurs at the last nucleotide of exon 52 and does not alter the amino acid at this position. It has been identified in 0.002% of Non-Finnish European chromosomes by the Exome Aggregation Consortium (ExAC: http://exac.broadinstitute.org; dbSNP). This variant has been reported in two homozygous and one compound heterozygous individuals with ataxia-telangiectasia (PMID: 9792409 and 26693373). It has been demonstrated to cause altered splicing, leading to deletion of 53 amino acids in exon 52 (PMID: 9792409). This region includes part of the FAT domain, which has been suggested to be important for proper activity of the protein (PMID: 23532176, 25460276, 10782091, 27229179). In summary, based on the previous reports of this variant in individuals with ataxia-telangiectasia and its impact on the protein, this variant meets our criteria to be classified as pathogenic. ATM truncating mutations may increase the risk of breast cancer and pancreatic cancer (PMID: 21787400; PMID: 22585167) and have been reported in families with familial prostate cancer (PMID: 24556621.) Ataxia-telangiectasia is an autosomal recessive condition characterized by progressive cerebellar ataxia, telangiectasias, immunodeficiency, and increased cancer risks and is caused by two mutations (one affecting each allele) in the ATM gene. If an ATM mutation carrier's partner is heterozygous for a pathogenic ATM mutation, there is a 25% risk that each child would be affected by ataxia-telangiectasia.",
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2700,12 +2699,12 @@
                         "totalPatientCount": 70067,
                         "genePatientCount": 1512
                     },
-                    "mskimpact_nonsignedout": {
+                    "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 87119,
-                        "genePatientCount": 797
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 6
                     },
                     "genie": {
                         "germlineVariantsCount": 0,
@@ -2714,15 +2713,16 @@
                         "totalPatientCount": 60702,
                         "genePatientCount": 1288
                     },
-                    "tcga": {
+                    "mskimpact_nonsignedout": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 10953,
-                        "genePatientCount": 6
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 797
                     }
                 },
-                "mutationOrigin": "germline"
+                "mutationOrigin": "germline",
+                "variantNote": "This heterozygous ATM c.7788G>A p.Glu2596Glu variant is a synonymous variant that occurs at the last nucleotide of exon 52 and does not alter the amino acid at this position. It has been identified in 0.002% of Non-Finnish European chromosomes by the Exome Aggregation Consortium (ExAC: http://exac.broadinstitute.org; dbSNP). This variant has been reported in two homozygous and one compound heterozygous individuals with ataxia-telangiectasia (PMID: 9792409 and 26693373). It has been demonstrated to cause altered splicing, leading to deletion of 53 amino acids in exon 52 (PMID: 9792409). This region includes part of the FAT domain, which has been suggested to be important for proper activity of the protein (PMID: 23532176, 25460276, 10782091, 27229179). In summary, based on the previous reports of this variant in individuals with ataxia-telangiectasia and its impact on the protein, this variant meets our criteria to be classified as pathogenic. ATM truncating mutations may increase the risk of breast cancer and pancreatic cancer (PMID: 21787400; PMID: 22585167) and have been reported in families with familial prostate cancer (PMID: 24556621.) Ataxia-telangiectasia is an autosomal recessive condition characterized by progressive cerebellar ataxia, telangiectasias, immunodeficiency, and increased cancer risks and is caused by two mutations (one affecting each allele) in the ATM gene. If an ATM mutation carrier's partner is heterozygous for a pathogenic ATM mutation, there is a 25% risk that each child would be affected by ataxia-telangiectasia."
             },
             {
                 "variant": "11:g.108151895G>A",
@@ -2747,7 +2747,6 @@
                         "referenceText": "Demuth et al., 2011"
                     }
                 ],
-                "variantNote": "This heterozygous ATM c.3576G>A variant is a synonymous alteration that does not change a Lysine to another amino acid at codon 1192 (p.Lys1192=). This variant occurs in the last nucleotide of an exon and leads to aberrant splicing leading to exon skipping according to in-vitro RNA studies (PMID: 9887333, 16941484, 21965147). This variant has been identified in 4/113572 of Non-Finnish European chromosomes by the Genome Aggregation Database (http://gnomad.broadinstitute.org/;), and has been reported in multiple individuals with ataxia telangiectasia in heterozygous (in-trans with another pathogenic ATM variant) or homozygous states (PMID: 30819809, 8845835, 9443866, 9792409, 9887333, 10330348, 12552559, 16941484, 17124347). Furthermore, this variant has been detected in patients with breast, thyroid or ampullary cancers (PMID: 27599564, 30620386, 31300551). In summary, based on the previous reports of this variant in individuals with ATM associated disease and in-vitro functional studies, this variant is classified as pathogenic. ATM truncating mutations may increase the risk of breast cancer and pancreatic cancer (PMID: 21787400; PMID: 22585167) and have been reported in families with familial prostate cancer (PMID: 24556621.) Ataxia-telangiectasia is an autosomal recessive condition characterized by progressive cerebellar ataxia, telangiectasias, immunodeficiency, and increased cancer risks and is caused by two mutations (one affecting each allele) in the ATM gene. If an ATM mutation carrier's partner is heterozygous for a pathogenic ATM mutation, there is a 25% risk that each child would be affected by ataxia-telangiectasia.",
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -2756,12 +2755,12 @@
                         "totalPatientCount": 70067,
                         "genePatientCount": 1512
                     },
-                    "mskimpact_nonsignedout": {
+                    "tcga": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 1,
+                        "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 87119,
-                        "genePatientCount": 797
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 6
                     },
                     "genie": {
                         "germlineVariantsCount": 0,
@@ -2770,15 +2769,16 @@
                         "totalPatientCount": 60702,
                         "genePatientCount": 1288
                     },
-                    "tcga": {
+                    "mskimpact_nonsignedout": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 0,
+                        "somaticVariantsCount": 1,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 10953,
-                        "genePatientCount": 6
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 797
                     }
                 },
-                "mutationOrigin": "germline"
+                "mutationOrigin": "germline",
+                "variantNote": "This heterozygous ATM c.3576G>A variant is a synonymous alteration that does not change a Lysine to another amino acid at codon 1192 (p.Lys1192=). This variant occurs in the last nucleotide of an exon and leads to aberrant splicing leading to exon skipping according to in-vitro RNA studies (PMID: 9887333, 16941484, 21965147). This variant has been identified in 4/113572 of Non-Finnish European chromosomes by the Genome Aggregation Database (http://gnomad.broadinstitute.org/;), and has been reported in multiple individuals with ataxia telangiectasia in heterozygous (in-trans with another pathogenic ATM variant) or homozygous states (PMID: 30819809, 8845835, 9443866, 9792409, 9887333, 10330348, 12552559, 16941484, 17124347). Furthermore, this variant has been detected in patients with breast, thyroid or ampullary cancers (PMID: 27599564, 30620386, 31300551). In summary, based on the previous reports of this variant in individuals with ATM associated disease and in-vitro functional studies, this variant is classified as pathogenic. ATM truncating mutations may increase the risk of breast cancer and pancreatic cancer (PMID: 21787400; PMID: 22585167) and have been reported in families with familial prostate cancer (PMID: 24556621.) Ataxia-telangiectasia is an autosomal recessive condition characterized by progressive cerebellar ataxia, telangiectasias, immunodeficiency, and increased cancer risks and is caused by two mutations (one affecting each allele) in the ATM gene. If an ATM mutation carrier's partner is heterozygous for a pathogenic ATM mutation, there is a 25% risk that each child would be affected by ataxia-telangiectasia."
             }
         ]
     },
@@ -3057,10 +3057,9 @@
                 "references": [
                     {
                         "pubmedId": "29368626",
-                        "referenceText": "Weber-Lassalle et al. 2018"
+                        "referenceText": "Weber-Lassalle et al., 2018"
                     }
                 ],
-                "variantNote": "This silent sequence change affects codon 169 of the BRIP1 mRNA and does not change the encoded amino acid sequence (p.Gln169=). This variant falls at the last nucleotide of BRIP1 exon 5. This variant is absent from large population databases (1000 Genomes, ESP, and gnomAD), and has been reported in the literature in individuals with breast and ovarian cancers (PMID: 29368626). An experimental study using patient RNA showed that this variant led to skipping of exon 5 and a prematurely truncated protein product (PMID: 29368626). In summary, although additional studies are required to fully establish its clinical significance, this BRIp1 c.507G>A p.Gln169= variant is classified as likely pathogenic. Heterozygous pathogenic variants in BRIP1 have been associated with an increased risk of ovarian cancer (PMID: 26315354, 2196457) and may increase the risk of breast cancer (PMID: 17033622). Biallelic mutations in BRIP1 have been associated with Fanconi Anemia, an autosomal recessive condition characterized by physical abnormalities, bone marrow failure, and increased risk of malignancy. If a BRIP1 mutation carrier's partner is heterozygous for a pathogenic BRIP1 mutation, there is a 25% risk that each child would be affected by Fanconi Anemia.",
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -3069,12 +3068,12 @@
                         "totalPatientCount": 70067,
                         "genePatientCount": 195
                     },
-                    "mskimpact_nonsignedout": {
+                    "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 87119,
-                        "genePatientCount": 163
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
                     },
                     "genie": {
                         "germlineVariantsCount": 0,
@@ -3083,15 +3082,16 @@
                         "totalPatientCount": 60702,
                         "genePatientCount": 156
                     },
-                    "tcga": {
+                    "mskimpact_nonsignedout": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 10953,
-                        "genePatientCount": 0
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 163
                     }
                 },
-                "mutationOrigin": "germline"
+                "mutationOrigin": "germline",
+                "variantNote": "This silent sequence change affects codon 169 of the BRIP1 mRNA and does not change the encoded amino acid sequence (p.Gln169=). This variant falls at the last nucleotide of BRIP1 exon 5. This variant is absent from large population databases (1000 Genomes, ESP, and gnomAD), and has been reported in the literature in individuals with breast and ovarian cancers (PMID: 29368626). An experimental study using patient RNA showed that this variant led to skipping of exon 5 and a prematurely truncated protein product (PMID: 29368626). In summary, although additional studies are required to fully establish its clinical significance, this BRIp1 c.507G>A p.Gln169= variant is classified as likely pathogenic. Heterozygous pathogenic variants in BRIP1 have been associated with an increased risk of ovarian cancer (PMID: 26315354, 2196457) and may increase the risk of breast cancer (PMID: 17033622). Biallelic mutations in BRIP1 have been associated with Fanconi Anemia, an autosomal recessive condition characterized by physical abnormalities, bone marrow failure, and increased risk of malignancy. If a BRIP1 mutation carrier's partner is heterozygous for a pathogenic BRIP1 mutation, there is a 25% risk that each child would be affected by Fanconi Anemia."
             },
             {
                 "variant": "17:g.59938807C>T",
@@ -3467,10 +3467,10 @@
     {
         "hugoGeneSymbol": "MLH1",
         "transcriptId": "ENST00000231790",
-        "genomicLocationDescription": "Last nucleotide of exon 15",
+        "genomicLocationDescription": "Last nucleotide of exon 15;Alterations on the ESE motifs cause deletion of exons",
         "defaultEffect": "splice",
-        "comment": "Skipping of exon 15 and leads to an out-of-frame transcript and premature protein truncation",
-        "context": "In Lynch syndrome colorectal cancer",
+        "comment": "Skipping of exon 15 and leads to an out-of-frame transcript and premature protein truncation; Alters number of ESEs affecting transcription",
+        "context": "In Lynch syndrome colorectal cancer and multiple cancer types",
         "revisedProteinEffects": [
             {
                 "variant": "3:g.37083822G>A",
@@ -3484,18 +3484,112 @@
                 "references": [
                     {
                         "pubmedId": "16341550",
-                        "referenceText": "Pagenstecher et al. 2006"
+                        "referenceText": "Pagenstecher et al., 2006"
                     },
                     {
                         "pubmedId": "18561205",
-                        "referenceText": "Tournier et al. 2008"
+                        "referenceText": "Tournier et al., 2008"
                     },
                     {
                         "pubmedId": "16451135",
-                        "referenceText": "Kurzawski et al. 2006"
+                        "referenceText": "Kurzawski et al., 2006"
                     }
                 ],
-                "variantNote": "The heterozygous germline variant, MLH1 c.1731G>A (p.Ser577Ser), results in a silent mutation and occurs at the last nucleotide of exon 15. This variant is absent from the major population databases (1000G, ESP and gnomAD). It is a well known pathogenic variant that has been reported in several individuals and families with Lynch syndrome (PMID: 16341550, 15849733, 20223024, 26300997, 14635101, 16216036, 16395668, 19669161). Experimental studies using mRNA isolated from patients blood as well as a reporter minigene assay showed that this variant results in the skipping of exon 15 and leads to an out-of-frame transcript and premature protein truncation (PMID: 16341550, 18561205, 16451135). In summary, based on the previous reports of this variant in individuals with MLH1 associated cancers and its truncating effect on the protein, this variant meets our criteria to be classified as pathogenic. Lynch syndrome is an autosomal dominant condition that confers an increased risk for colorectal cancer and endometrial cancers as well as other cancers. There is a 50% chance that each child would inherit this variant from a carrier parent.",
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 9
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 8
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 6,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 53
+                    }
+                },
+                "mutationOrigin": "germline",
+                "variantNote": "The heterozygous germline variant, MLH1 c.1731G>A (p.Ser577Ser), results in a silent mutation and occurs at the last nucleotide of exon 15. This variant is absent from the major population databases (1000G, ESP and gnomAD). It is a well known pathogenic variant that has been reported in several individuals and families with Lynch syndrome (PMID: 16341550, 15849733, 20223024, 26300997, 14635101, 16216036, 16395668, 19669161). Experimental studies using mRNA isolated from patients blood as well as a reporter minigene assay showed that this variant results in the skipping of exon 15 and leads to an out-of-frame transcript and premature protein truncation (PMID: 16341550, 18561205, 16451135). In summary, based on the previous reports of this variant in individuals with MLH1 associated cancers and its truncating effect on the protein, this variant meets our criteria to be classified as pathogenic. Lynch syndrome is an autosomal dominant condition that confers an increased risk for colorectal cancer and endometrial cancers as well as other cancers. There is a 50% chance that each child would inherit this variant from a carrier parent."
+            },
+            {
+                "variant": "3:g.37059048C>T",
+                "genomicLocation": "3,37059048,37059048,C,T",
+                "transcriptId": "ENST00000231790",
+                "vepPredictedProteinEffect": "p.A281V",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.H264Lfs*2",
+                "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "16995940",
+                        "referenceText": "Lastella et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 9
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 53
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 8
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 1,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                },
+                "variantNote": "Alterations on the ESE motifs cause deletion of exons, affects splicing across multiple cancer types"
+            },
+            {
+                "variant": "3:g.37090087G>C",
+                "genomicLocation": "3,37090087,37090087,G,C",
+                "transcriptId": "ENST00000231790",
+                "vepPredictedProteinEffect": "p.R659P",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.E633_E663del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "16995940",
+                        "referenceText": "Lastella et al., 2006"
+                    }
+                ],
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -3506,7 +3600,7 @@
                     },
                     "mskimpact_nonsignedout": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 6,
+                        "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
                         "totalPatientCount": 87119,
                         "genePatientCount": 53
@@ -3526,7 +3620,7 @@
                         "genePatientCount": 0
                     }
                 },
-                "mutationOrigin": "germline"
+                "variantNote": "Alterations on the ESE motifs cause deletion of exons, affects splicing across multiple cancer types"
             },
             {
                 "variant": "3:g.37050394C>T",
@@ -3745,10 +3839,9 @@
                 "references": [
                     {
                         "pubmedId": "11420676",
-                        "referenceText": "Varley et al. 2001"
+                        "referenceText": "Varley et al., 2001"
                     }
                 ],
-                "variantNote": "The heterozygous germline variant, TP53 c.375G>T (Thr125=), is located at the last nucleotide of exon 4 of the TP53 gene. This variant is absent from large population databases (1000 Genomes, ESP, and gnomAD). It has been reported in a family with Li Fraumeni syndrome (PMID: 11420676). In vitro studies and analysis of RNA from patient cells demonstrated that this variant leads to aberrant splicing (PMID: 11420676, 25730903). Two other variants at this position (c.375G>A and c.375G>C) have been reported in individuals and families with Li Fraumeni syndrome (PMID: 9242456, 10864200, 11420676, 24382691, 31105275). In summary, although additional studies are required to fully establish its clinical significance, based on its previous report in an individual with Li Fraumeni syndrome and its demonstrated impact on splicing, this c.375G>T (p.?) variant is classified as likely pathogenic. Li-Fraumeni syndrome (LFS) is an autosomal dominant cancer predisposition syndrome associated with an increased risk of tumors including soft tissue sarcoma, osteosarcoma, pre-menopausal breast cancer, brain tumors, adrenocortical carcinoma (ACC), and leukemias (http://www.ncbi.nlm.nih.gov/books/NBK1311/).",
                 "counts": {
                     "mskimpact": {
                         "germlineVariantsCount": 0,
@@ -3757,12 +3850,12 @@
                         "totalPatientCount": 70067,
                         "genePatientCount": 1217
                     },
-                    "mskimpact_nonsignedout": {
+                    "tcga": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 124,
-                        "unknownVariantsCount": 2,
-                        "totalPatientCount": 87119,
-                        "genePatientCount": 283
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 25,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 1
                     },
                     "genie": {
                         "germlineVariantsCount": 0,
@@ -3771,15 +3864,358 @@
                         "totalPatientCount": 60702,
                         "genePatientCount": 1109
                     },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 124,
+                        "unknownVariantsCount": 2,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 283
+                    }
+                },
+                "mutationOrigin": "germline",
+                "variantNote": "The heterozygous germline variant, TP53 c.375G>T (Thr125=), is located at the last nucleotide of exon 4 of the TP53 gene. This variant is absent from large population databases (1000 Genomes, ESP, and gnomAD). It has been reported in a family with Li Fraumeni syndrome (PMID: 11420676). In vitro studies and analysis of RNA from patient cells demonstrated that this variant leads to aberrant splicing (PMID: 11420676, 25730903). Two other variants at this position (c.375G>A and c.375G>C) have been reported in individuals and families with Li Fraumeni syndrome (PMID: 9242456, 10864200, 11420676, 24382691, 31105275). In summary, although additional studies are required to fully establish its clinical significance, based on its previous report in an individual with Li Fraumeni syndrome and its demonstrated impact on splicing, this c.375G>T (p.?) variant is classified as likely pathogenic. Li-Fraumeni syndrome (LFS) is an autosomal dominant cancer predisposition syndrome associated with an increased risk of tumors including soft tissue sarcoma, osteosarcoma, pre-menopausal breast cancer, brain tumors, adrenocortical carcinoma (ACC), and leukemias (http://www.ncbi.nlm.nih.gov/books/NBK1311/)."
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "F11",
+        "transcriptId": "ENST00000403665",
+        "genomicLocationDescription": "Alterations in Exon Splice Enhancement Sites (ESE) affecting multiple exons",
+        "defaultEffect": "missense",
+        "comment": "Alters number of ESEs affecting transcription and causing aberrant splicing",
+        "context": "Largely found in cancer-related thrombosis",
+        "revisedProteinEffects": [
+            {
+                "variant": "4:g.187208954G>A",
+                "genomicLocation": "4,187208954,187208954,G,A",
+                "transcriptId": "ENST00000403665",
+                "vepPredictedProteinEffect": "p.E565K",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.D526_G572del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21718436",
+                        "referenceText": "Zucker et al., 2011"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 0
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 0
+                    },
                     "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
-                        "unknownVariantsCount": 25,
+                        "unknownVariantsCount": 0,
                         "totalPatientCount": 10953,
-                        "genePatientCount": 1
+                        "genePatientCount": 0
                     }
-                },
-                "mutationOrigin": "germline"
+                }
+            },
+            {
+                "variant": "4:g.187201659G>A",
+                "genomicLocation": "4,187201659,187201659,G,A",
+                "transcriptId": "ENST00000403665",
+                "vepPredictedProteinEffect": "p.G350R",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.K343_E379del",
+                "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21718436",
+                        "referenceText": "Zucker et al., 2011"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 0
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 0
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 1,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                }
+            },
+            {
+                "variant": "4:g.187197405C>T",
+                "genomicLocation": "4,187197405,187197405,C,T",
+                "transcriptId": "ENST00000403665",
+                "vepPredictedProteinEffect": "p.P206S",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.A199_R252del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21718436",
+                        "referenceText": "Zucker et al., 2011"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 0
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 0
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "MSH2",
+        "transcriptId": "ENST00000233146",
+        "genomicLocationDescription": "Alterations on the ESE motifs cause skipping of exons",
+        "defaultEffect": "missense",
+        "comment": "Alters number of ESEs affecting transcription",
+        "context": "Affects splicing across multiple cancer types",
+        "revisedProteinEffects": [
+            {
+                "variant": "2:g.47641421C>T",
+                "genomicLocation": "2,47641421,47641421,C,T",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.S269L",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.V265_Q314del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "16995940",
+                        "referenceText": "Lastella et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 22
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 21
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 17
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                }
+            },
+            {
+                "variant": "2:g.47641430C>T",
+                "genomicLocation": "2,47641430,47641430,C,T",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.A272V",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.V265_Q314del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "16995940",
+                        "referenceText": "Lastella et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 5,
+                        "unknownVariantsCount": 1,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 22
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 21
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 3,
+                        "unknownVariantsCount": 1,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 17
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                }
+            },
+            {
+                "variant": "2:g.47693802G>T",
+                "genomicLocation": "2,47693802,47693802,G,T",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.D506Y",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.G504Afs*3",
+                "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "16995940",
+                        "referenceText": "Lastella et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 2,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 22
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 21
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 17
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                }
+            },
+            {
+                "variant": "2:g.47693886C>T",
+                "genomicLocation": "2,47693886,47693886,C,T",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.R534C",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.G504Afs*3",
+                "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "16995940",
+                        "referenceText": "Lastella et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 4,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 22
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 21
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 4,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 17
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                }
             }
         ]
     }


### PR DESCRIPTION
@4DPrinted curated these VUEs: https://github.com/knowledgesystems/reVUE-data/blob/ThomasC-patch-1/VUEs.json#L2651-L2787

Summary:
- F11: 3
- MLH1: 2
- MSH2: 4