### PR TITLE
Add MSH2, MLH1, BRCA2, RB1, CDH1 variants

### DIFF
--- a/VUEs.json
+++ b/VUEs.json
@@ -15,6 +15,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.K550_K558del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 10",
+                "endLocation": "exon 11",
                 "confirmed": true,
                 "references": [
                     {
@@ -61,6 +64,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.K550_K558del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 10",
+                "endLocation": "exon 11",
                 "confirmed": true,
                 "references": [
                     {
@@ -107,6 +113,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.K550_K558del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 10",
+                "endLocation": "exon 11",
                 "confirmed": true,
                 "references": [
                     {
@@ -163,6 +172,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.G279Ffs*10",
                 "revisedVariantClassification": "Splice_Exon_Extension_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Ins",
+                "startLocation": "intron 8",
+                "endLocation": "intron 8",
                 "confirmed": true,
                 "references": [
                     {
@@ -219,6 +231,9 @@
                 "vepPredictedVariantClassification": "Silent",
                 "revisedProteinEffect": "p.D311Gfs*23",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "exon 11",
+                "endLocation": "exon 11",
                 "confirmed": false,
                 "references": [
                     {
@@ -275,6 +290,9 @@
                 "vepPredictedVariantClassification": "Missense_Mutation",
                 "revisedProteinEffect": "p.X61",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "exon 3",
+                "endLocation": "exon 3",
                 "confirmed": false,
                 "references": [
                     {
@@ -331,6 +349,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.Q28_D81del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 3",
+                "endLocation": "intron 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -377,6 +398,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 2",
+                "endLocation": "intron 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -423,6 +447,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.M12_D81del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 3",
+                "endLocation": "intron 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -469,6 +496,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_Q72del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 2",
+                "endLocation": "exon 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -515,6 +545,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.S29_D81del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 3",
+                "endLocation": "intron 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -561,6 +594,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 2",
+                "endLocation": "intron 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -607,6 +643,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 2",
+                "endLocation": "intron 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -653,6 +692,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.E9_D81del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 3",
+                "endLocation": "intron 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -699,6 +741,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.E9_D81del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 3",
+                "endLocation": "intron 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -745,6 +790,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 2",
+                "endLocation": "intron 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -791,6 +839,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_G69del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 2",
+                "endLocation": "exon 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -837,6 +888,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_Q79del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 2",
+                "endLocation": "exon 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -883,6 +937,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 2",
+                "endLocation": "intron 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -929,6 +986,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_Q72del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 2",
+                "endLocation": "exon 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -975,6 +1035,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_E9del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 2",
+                "endLocation": "exon 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -1021,6 +1084,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A2_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 2",
+                "endLocation": "intron 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -1067,6 +1133,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.Q4_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 2",
+                "endLocation": "intron 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -1107,12 +1176,15 @@
             },
             {
                 "variant": "3:g.41265571_41266206del",
-                "genomicLocation": "3,41265571,4126620,AGGTTTGTGTCATTAAATCTTTAGTTACTGAATTGGGGCTCTGCTTCGTTGCCATTAAGCCAGTCTGGCTGAGATCCCCCTGCTTTCCTCTCTCCCTGCTTACTTGTCAGGCTACCTTTTGCTCCATTTTCTGCTCACTCCTCCTAATGGCTTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACA,-",
+                "genomicLocation": "3,41265571,41266206,AGGTTTGTGTCATTAAATCTTTAGTTACTGAATTGGGGCTCTGCTTCGTTGCCATTAAGCCAGTCTGGCTGAGATCCCCCTGCTTTCCTCTCTCCCTGCTTACTTGTCAGGCTACCTTTTGCTCCATTTTCTGCTCACTCCTCCTAATGGCTTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACA,-",
                 "transcriptId": "ENST00000349496",
                 "vepPredictedProteinEffect": "p.X4_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_Q68del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 2",
+                "endLocation": "exon 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -1159,6 +1231,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_A97del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 2",
+                "endLocation": "exon 4",
                 "confirmed": true,
                 "references": [
                     {
@@ -1205,6 +1280,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_F70del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 2",
+                "endLocation": "exon 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -1251,6 +1329,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A5_Q68del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 2",
+                "endLocation": "exon 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -1307,6 +1388,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 14",
+                "endLocation": "intron 14",
                 "confirmed": false,
                 "references": [
                     {
@@ -1353,6 +1437,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 13",
+                "endLocation": "intron 14",
                 "confirmed": false,
                 "references": [
                     {
@@ -1399,6 +1486,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 13",
+                "endLocation": "intron 14",
                 "confirmed": false,
                 "references": [
                     {
@@ -1445,6 +1535,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 13",
+                "endLocation": "intron 13",
                 "confirmed": false,
                 "references": [
                     {
@@ -1491,6 +1584,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 13",
+                "endLocation": "intron 13",
                 "confirmed": false,
                 "references": [
                     {
@@ -1537,6 +1633,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 13",
+                "endLocation": "exon 14",
                 "confirmed": false,
                 "references": [
                     {
@@ -1583,6 +1682,9 @@
                 "vepPredictedVariantClassification": "Intron",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 13",
+                "endLocation": "intron 13",
                 "confirmed": false,
                 "references": [
                     {
@@ -1629,6 +1731,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 13",
+                "endLocation": "intron 13",
                 "confirmed": false,
                 "references": [
                     {
@@ -1675,6 +1780,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 14",
+                "endLocation": "intron 14",
                 "confirmed": false,
                 "references": [
                     {
@@ -1721,6 +1829,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 13",
+                "endLocation": "intron 13",
                 "confirmed": false,
                 "references": [
                     {
@@ -1767,6 +1878,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 13",
+                "endLocation": "exon 14",
                 "confirmed": false,
                 "references": [
                     {
@@ -1813,6 +1927,9 @@
                 "vepPredictedVariantClassification": "Missense_Mutation",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 14",
+                "endLocation": "exon 14",
                 "confirmed": false,
                 "references": [
                     {
@@ -1859,6 +1976,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 13",
+                "endLocation": "intron 13",
                 "confirmed": false,
                 "references": [
                     {
@@ -1905,6 +2025,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 14",
+                "endLocation": "intron 14",
                 "confirmed": false,
                 "references": [
                     {
@@ -1951,6 +2074,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 13",
+                "endLocation": "intron 13",
                 "confirmed": false,
                 "references": [
                     {
@@ -1997,6 +2123,9 @@
                 "vepPredictedVariantClassification": "Intron",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 13",
+                "endLocation": "intron 13",
                 "confirmed": false,
                 "references": [
                     {
@@ -2043,6 +2172,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 14",
+                "endLocation": "intron 14",
                 "confirmed": false,
                 "references": [
                     {
@@ -2089,6 +2221,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 13",
+                "endLocation": "intron 13",
                 "confirmed": false,
                 "references": [
                     {
@@ -2135,6 +2270,9 @@
                 "vepPredictedVariantClassification": "Intron",
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 13",
+                "endLocation": "intron 13",
                 "confirmed": false,
                 "references": [
                     {
@@ -2191,6 +2329,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.D434_E476del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 11",
+                "endLocation": "intron 11",
                 "confirmed": false,
                 "references": [
                     {
@@ -2247,6 +2388,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.E598_F612dup",
                 "revisedVariantClassification": "Splice_Exon_Extension_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Ins",
+                "startLocation": "intron 13",
+                "endLocation": "intron 13",
                 "confirmed": false,
                 "references": [
                     {
@@ -2303,6 +2447,9 @@
                 "vepPredictedVariantClassification": "Missense_Mutation",
                 "revisedProteinEffect": "p.C222Qfs*2",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "exon 7",
+                "endLocation": "exon 7",
                 "confirmed": false,
                 "references": [
                     {
@@ -2350,6 +2497,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.I709_K750del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 14",
+                "endLocation": "exon 14",
                 "confirmed": true,
                 "references": [
                     {
@@ -2402,6 +2552,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A823Vfs*5",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "intron 17",
+                "endLocation": "intron 17",
                 "confirmed": false,
                 "references": [
                     {
@@ -2449,6 +2602,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.V1833Ifs*63",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "intron 36",
+                "endLocation": "intron 36",
                 "confirmed": false,
                 "references": [
                     {
@@ -2496,6 +2652,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.N2326_K2363del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 47",
+                "endLocation": "intron 47",
                 "confirmed": false,
                 "references": [
                     {
@@ -2543,6 +2702,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.N2326_K2363del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 48",
+                "endLocation": "intron 48",
                 "confirmed": false,
                 "references": [
                     {
@@ -2590,6 +2752,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.V2757_M2806del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 57",
+                "endLocation": "intron 57",
                 "confirmed": false,
                 "references": [
                     {
@@ -2637,6 +2802,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.S2996Rfs*5",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "intron 62",
+                "endLocation": "intron 62",
                 "confirmed": false,
                 "references": [
                     {
@@ -2684,6 +2852,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.L2544_E2596del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 52",
+                "endLocation": "exon 52",
                 "confirmed": true,
                 "references": [
                     {
@@ -2732,6 +2903,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.S1135_K1192",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 24",
+                "endLocation": "exon 24",
                 "confirmed": true,
                 "references": [
                     {
@@ -2798,6 +2972,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A1844Dfs*2",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "intron 21",
+                "endLocation": "intron 21",
                 "confirmed": false,
                 "references": [
                     {
@@ -2845,6 +3022,9 @@
                 "vepPredictedVariantClassification": "Missense_Mutation",
                 "revisedProteinEffect": "p.A1453Gfs*9",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "exon 13",
+                "endLocation": "exon 13",
                 "confirmed": false,
                 "references": [
                     {
@@ -2902,6 +3082,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.G173Sfs*17",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "intron 6",
+                "endLocation": "intron 6",
                 "confirmed": false,
                 "references": [
                     {
@@ -2949,6 +3132,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.L2540Qfs*10",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "intron 15",
+                "endLocation": "intron 15",
                 "confirmed": false,
                 "references": [
                     {
@@ -2996,6 +3182,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.V2985Gfs*3",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "exon 23",
+                "endLocation": "exon 23",
                 "confirmed": false,
                 "references": [
                     {
@@ -3053,6 +3242,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.D127Dfs*1",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "exon 5",
+                "endLocation": "exon 5",
                 "confirmed": true,
                 "references": [
                     {
@@ -3101,6 +3293,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.M1_S31del",
                 "revisedVariantClassification": "Splice_Exon_Skip_Non_Start",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 1",
+                "endLocation": "intron 1",
                 "confirmed": false,
                 "references": [
                     {
@@ -3158,6 +3353,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.T523*",
                 "revisedVariantClassification": "Splice_Exon_Extension_Nonsense",
+                "revisedStandardVariantClassification": "Nonsense_Mutation",
+                "startLocation": "intron 10",
+                "endLocation": "intron 10",
                 "confirmed": false,
                 "references": [
                     {
@@ -3205,6 +3403,9 @@
                 "vepPredictedVariantClassification": "Missense_Mutation",
                 "revisedProteinEffect": "p.Y523Ffs*15",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "exon 11",
+                "endLocation": "exon 11",
                 "confirmed": false,
                 "references": [
                     {
@@ -3243,6 +3444,61 @@
                     }
                 },
                 "mutationOrigin": "germline"
+            },
+            {
+                "variant": "16:g.68845762G>A",
+                "genomicLocation": "16,68845762,68845762,G,A",
+                "transcriptId": "ENST00000261769",
+                "vepPredictedProteinEffect": "p.X336_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.S337Vfs*14",
+                "revisedVariantClassification": "Splice_Exon_Extension_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Ins",
+                "startLocation": "exon 7",
+                "endLocation": "exon 7",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "8127895",
+                        "referenceText": "Oda et al., 1994"
+                    },
+                    {
+                        "pubmedId": "18427545",
+                        "referenceText": "Karam et al., 2008"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 818
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 170
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 729
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 1,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                },
+                "variantNote": "The heterozygous germline variant, CDH1 c.1008G>A (p.Glu336=) is located at the last nucleotide of exon 7 of the CDH1 gene. This variant is absent from large population databases (1000 Genomes, ESP, and gnomAD) and has been reported in an individual affected with diffuse gastric cancer (PMID: 27730413). Experimental studies and analysis of RNA demonstrated that this variant leads to aberrant splicing (PMID: 8127895, 18427545). Additionally, a different variant at this position (c.1008G>T) has been reported in a family affected with hereditary diffuse gastric cancer (PMID: 9537325, 19725995). In summary, although additional studies are required to fully establish its clinical significance, this c.1008G>A variant is classified as likely pathogenic.\nPathogenic variants in CDH1 cause hereditary diffuse gastric cancer which is an autosomal dominant characterized by susceptibility to diffuse gastric cancer (also referred to as signet ring carcinoma or isolated cell-type carcinoma) and lobular breast cancer (https://www.ncbi.nlm.nih.gov/books/NBK1139/). Relatives of an individual with a pathogenic CDH1 variant have up-to 50% probability of carrying the same variant, and carriers are at an increased risk of developingCDH1-associated disease.",
+                "otherVariation": "Can also be 25, 42, 150 bp intron 7 insertion, and whole intron 7 insertions"
             }
         ]
     },
@@ -3262,6 +3518,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.E149Ifs*5",
                 "revisedVariantClassification": "Splice_Exon_Extension_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Ins",
+                "startLocation": "intron 2",
+                "endLocation": "intron 2",
                 "confirmed": false,
                 "references": [
                     {
@@ -3319,6 +3578,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.A946_G999del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 7",
+                "endLocation": "intron 7",
                 "confirmed": false,
                 "references": [
                     {
@@ -3366,6 +3628,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.T839_K862del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 4",
+                "endLocation": "intron 4",
                 "confirmed": false,
                 "references": [
                     {
@@ -3423,6 +3688,9 @@
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.P322Vfs*5",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "intron 8",
+                "endLocation": "intron 8",
                 "confirmed": false,
                 "references": [
                     {
@@ -3480,6 +3748,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.S556Rfs*13",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "exon 15",
+                "endLocation": "exon 15",
                 "confirmed": true,
                 "references": [
                     {
@@ -3536,6 +3807,9 @@
                 "vepPredictedVariantClassification": "Missense_Mutation",
                 "revisedProteinEffect": "p.H264Lfs*2",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "exon 10",
+                "endLocation": "exon 10",
                 "confirmed": false,
                 "references": [
                     {
@@ -3551,12 +3825,12 @@
                         "totalPatientCount": 70067,
                         "genePatientCount": 9
                     },
-                    "mskimpact_nonsignedout": {
+                    "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
-                        "unknownVariantsCount": 0,
-                        "totalPatientCount": 87119,
-                        "genePatientCount": 53
+                        "unknownVariantsCount": 1,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
                     },
                     "genie": {
                         "germlineVariantsCount": 0,
@@ -3565,12 +3839,12 @@
                         "totalPatientCount": 60702,
                         "genePatientCount": 8
                     },
-                    "tcga": {
+                    "mskimpact_nonsignedout": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
-                        "unknownVariantsCount": 1,
-                        "totalPatientCount": 10953,
-                        "genePatientCount": 0
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 53
                     }
                 },
                 "variantNote": "Alterations on the ESE motifs cause deletion of exons, affects splicing across multiple cancer types"
@@ -3583,6 +3857,9 @@
                 "vepPredictedVariantClassification": "Missense_Mutation",
                 "revisedProteinEffect": "p.E633_E663del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 17",
+                "endLocation": "exon 17",
                 "confirmed": false,
                 "references": [
                     {
@@ -3598,12 +3875,12 @@
                         "totalPatientCount": 70067,
                         "genePatientCount": 9
                     },
-                    "mskimpact_nonsignedout": {
+                    "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 87119,
-                        "genePatientCount": 53
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
                     },
                     "genie": {
                         "germlineVariantsCount": 0,
@@ -3612,12 +3889,12 @@
                         "totalPatientCount": 60702,
                         "genePatientCount": 8
                     },
-                    "tcga": {
+                    "mskimpact_nonsignedout": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 10953,
-                        "genePatientCount": 0
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 53
                     }
                 },
                 "variantNote": "Alterations on the ESE motifs cause deletion of exons, affects splicing across multiple cancer types"
@@ -3629,7 +3906,10 @@
                 "vepPredictedProteinEffect": "p.X181_splice",
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.G181Gfs*20",
-                "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
+                "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "exon 6",
+                "endLocation": "exon 6",
                 "confirmed": false,
                 "references": [
                     {
@@ -3668,6 +3948,218 @@
                     }
                 },
                 "mutationOrigin": "germline"
+            },
+            {
+                "variant": "3:g.37053309A>G",
+                "genomicLocation": "3,37053309,37053309,A,G",
+                "transcriptId": "ENST00000231790",
+                "vepPredictedProteinEffect": "p.X182_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.R84Sfs*5",
+                "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "intron 6",
+                "endLocation": "intron 6",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 9
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 53
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 8
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 1,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                },
+                "mutationOrigin": "germline"
+            },
+            {
+                "variant": "3:g.37053590G>T",
+                "genomicLocation": "3,37053590,37053590,G,T",
+                "transcriptId": "ENST00000231790",
+                "vepPredictedProteinEffect": "p.R226L",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.Q197Rfs*7",
+                "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "exon 8",
+                "endLocation": "exon 8",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "12362047",
+                        "referenceText": "Kurzawski et al., 2002"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 9
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 53
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 8
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                },
+                "mutationOrigin": "germline"
+            },
+            {
+                "variant": "3:g.37059089A>C",
+                "genomicLocation": "3,37059089,37059089,A,C",
+                "transcriptId": "ENST00000231790",
+                "vepPredictedProteinEffect": "p.S295R",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.H264Lfs*1",
+                "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "exon 10",
+                "endLocation": "exon 10",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "12362047",
+                        "referenceText": "Kurzawski et al., 2002"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 9
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 53
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 8
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                },
+                "mutationOrigin": "germline"
+            },
+            {
+                "variant": "3:g.37067499G>C",
+                "genomicLocation": "3,37067499,37067499,G,C",
+                "transcriptId": "ENST00000231790",
+                "vepPredictedProteinEffect": "p.X470_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.T347Kfs*7",
+                "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "intron 12",
+                "endLocation": "intron 12",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "12362047",
+                        "referenceText": "Kurzawski et al., 2002"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 9
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 53
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 8
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                },
+                "mutationOrigin": "germline"
             }
         ]
     },
@@ -3687,6 +4179,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.A763_Y764insFQEA",
                 "revisedVariantClassification": "Splice_Exon_Extension_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Ins",
+                "startLocation": "intron 19",
+                "endLocation": "intron 19",
                 "confirmed": true,
                 "references": [
                     {
@@ -3743,6 +4238,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.S33_T125del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 3",
+                "endLocation": "intron 3",
                 "confirmed": true,
                 "references": [
                     {
@@ -3779,7 +4277,8 @@
                         "totalPatientCount": 87119,
                         "genePatientCount": 283
                     }
-                }
+                },
+                "otherVariation": "Partial exon 4 skip, p.G59Vfs*23, Splice_Exon_Shortening_Out_Of_Frame"
             },
             {
                 "variant": "17:g.7579312C>A",
@@ -3789,6 +4288,9 @@
                 "vepPredictedVariantClassification": "Splice_Region",
                 "revisedProteinEffect": "p.S33_T125del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 4",
+                "endLocation": "exon 4",
                 "confirmed": true,
                 "references": [
                     {
@@ -3847,6 +4349,9 @@
                 "vepPredictedVariantClassification": "Missense_Mutation",
                 "revisedProteinEffect": "p.D526_G572del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 14",
+                "endLocation": "exon 14",
                 "confirmed": false,
                 "references": [
                     {
@@ -3862,11 +4367,11 @@
                         "totalPatientCount": 70067,
                         "genePatientCount": 0
                     },
-                    "mskimpact_nonsignedout": {
+                    "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 87119,
+                        "totalPatientCount": 10953,
                         "genePatientCount": 0
                     },
                     "genie": {
@@ -3876,11 +4381,11 @@
                         "totalPatientCount": 60702,
                         "genePatientCount": 0
                     },
-                    "tcga": {
+                    "mskimpact_nonsignedout": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 10953,
+                        "totalPatientCount": 87119,
                         "genePatientCount": 0
                     }
                 }
@@ -3893,6 +4398,9 @@
                 "vepPredictedVariantClassification": "Missense_Mutation",
                 "revisedProteinEffect": "p.K343_E379del",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "exon 10",
+                "endLocation": "exon 10",
                 "confirmed": false,
                 "references": [
                     {
@@ -3908,11 +4416,11 @@
                         "totalPatientCount": 70067,
                         "genePatientCount": 0
                     },
-                    "mskimpact_nonsignedout": {
+                    "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
-                        "unknownVariantsCount": 0,
-                        "totalPatientCount": 87119,
+                        "unknownVariantsCount": 1,
+                        "totalPatientCount": 10953,
                         "genePatientCount": 0
                     },
                     "genie": {
@@ -3922,11 +4430,11 @@
                         "totalPatientCount": 60702,
                         "genePatientCount": 0
                     },
-                    "tcga": {
+                    "mskimpact_nonsignedout": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
-                        "unknownVariantsCount": 1,
-                        "totalPatientCount": 10953,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
                         "genePatientCount": 0
                     }
                 }
@@ -3939,6 +4447,9 @@
                 "vepPredictedVariantClassification": "Missense_Mutation",
                 "revisedProteinEffect": "p.A199_R252del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 7",
+                "endLocation": "exon 7",
                 "confirmed": false,
                 "references": [
                     {
@@ -3954,11 +4465,11 @@
                         "totalPatientCount": 70067,
                         "genePatientCount": 0
                     },
-                    "mskimpact_nonsignedout": {
+                    "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 87119,
+                        "totalPatientCount": 10953,
                         "genePatientCount": 0
                     },
                     "genie": {
@@ -3968,11 +4479,11 @@
                         "totalPatientCount": 60702,
                         "genePatientCount": 0
                     },
-                    "tcga": {
+                    "mskimpact_nonsignedout": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 10953,
+                        "totalPatientCount": 87119,
                         "genePatientCount": 0
                     }
                 }
@@ -3995,6 +4506,9 @@
                 "vepPredictedVariantClassification": "Missense_Mutation",
                 "revisedProteinEffect": "p.V265_Q314del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 5",
+                "endLocation": "exon 5",
                 "confirmed": false,
                 "references": [
                     {
@@ -4010,12 +4524,12 @@
                         "totalPatientCount": 70067,
                         "genePatientCount": 22
                     },
-                    "mskimpact_nonsignedout": {
+                    "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 87119,
-                        "genePatientCount": 21
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
                     },
                     "genie": {
                         "germlineVariantsCount": 0,
@@ -4024,12 +4538,12 @@
                         "totalPatientCount": 60702,
                         "genePatientCount": 17
                     },
-                    "tcga": {
+                    "mskimpact_nonsignedout": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 10953,
-                        "genePatientCount": 0
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 21
                     }
                 }
             },
@@ -4041,6 +4555,9 @@
                 "vepPredictedVariantClassification": "Missense_Mutation",
                 "revisedProteinEffect": "p.V265_Q314del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "exon 5",
+                "endLocation": "exon 5",
                 "confirmed": false,
                 "references": [
                     {
@@ -4056,12 +4573,12 @@
                         "totalPatientCount": 70067,
                         "genePatientCount": 22
                     },
-                    "mskimpact_nonsignedout": {
+                    "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 87119,
-                        "genePatientCount": 21
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
                     },
                     "genie": {
                         "germlineVariantsCount": 0,
@@ -4070,12 +4587,12 @@
                         "totalPatientCount": 60702,
                         "genePatientCount": 17
                     },
-                    "tcga": {
+                    "mskimpact_nonsignedout": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 10953,
-                        "genePatientCount": 0
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 21
                     }
                 }
             },
@@ -4087,6 +4604,9 @@
                 "vepPredictedVariantClassification": "Missense_Mutation",
                 "revisedProteinEffect": "p.G504Afs*3",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "exon 10",
+                "endLocation": "exon 10",
                 "confirmed": false,
                 "references": [
                     {
@@ -4102,12 +4622,12 @@
                         "totalPatientCount": 70067,
                         "genePatientCount": 22
                     },
-                    "mskimpact_nonsignedout": {
+                    "tcga": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 87119,
-                        "genePatientCount": 21
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
                     },
                     "genie": {
                         "germlineVariantsCount": 0,
@@ -4116,12 +4636,12 @@
                         "totalPatientCount": 60702,
                         "genePatientCount": 17
                     },
-                    "tcga": {
+                    "mskimpact_nonsignedout": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
-                        "totalPatientCount": 10953,
-                        "genePatientCount": 0
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 21
                     }
                 }
             },
@@ -4133,6 +4653,9 @@
                 "vepPredictedVariantClassification": "Missense_Mutation",
                 "revisedProteinEffect": "p.G504Afs*3",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "exon 10",
+                "endLocation": "exon 10",
                 "confirmed": false,
                 "references": [
                     {
@@ -4148,16 +4671,73 @@
                         "totalPatientCount": 70067,
                         "genePatientCount": 22
                     },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 4,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 17
+                    },
                     "mskimpact_nonsignedout": {
                         "germlineVariantsCount": 0,
                         "somaticVariantsCount": 0,
                         "unknownVariantsCount": 0,
                         "totalPatientCount": 87119,
                         "genePatientCount": 21
+                    }
+                }
+            },
+            {
+                "variant": "2:g.47641560A>T",
+                "genomicLocation": "2,47641560,47641560,A,T",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.X314_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.V265_Q314del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 5",
+                "endLocation": "intron 5",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "33259954",
+                        "referenceText": "Oldfield et al., 2021"
+                    },
+                    {
+                        "pubmedId": "12362047",
+                        "referenceText": "Kurzawski et al., 2002"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 2,
+                        "somaticVariantsCount": 3,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 22
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 21
                     },
                     "genie": {
                         "germlineVariantsCount": 0,
-                        "somaticVariantsCount": 4,
+                        "somaticVariantsCount": 3,
                         "unknownVariantsCount": 0,
                         "totalPatientCount": 60702,
                         "genePatientCount": 17
@@ -4169,7 +4749,288 @@
                         "totalPatientCount": 10953,
                         "genePatientCount": 0
                     }
-                }
+                },
+                "mutationOrigin": "germline"
+            },
+            {
+                "variant": "2:g.47693952G>C",
+                "genomicLocation": "2,47693952,47693952,G,C",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.*554*",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.G504Afs*3",
+                "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "intron 10",
+                "endLocation": "intron 10",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "33259954",
+                        "referenceText": "Oldfield et al., 2021"
+                    },
+                    {
+                        "pubmedId": "12362047",
+                        "referenceText": "Kurzawski et al., 2002"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 22
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 21
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 17
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                },
+                "mutationOrigin": "germline"
+            },
+            {
+                "variant": "2:g.47637512G>T",
+                "genomicLocation": "2,47637512,47637512,G,T",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.X215_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A123_Q215del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "startLocation": "intron 3",
+                "endLocation": "intron 3",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "12362047",
+                        "referenceText": "Kurzawski et al., 2002"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 22
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 21
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 17
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                },
+                "mutationOrigin": "germline"
+            },
+            {
+                "variant": "2:g.47703711G>C",
+                "genomicLocation": "2,47703711,47703711,G,C",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.X737_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.G669Gfs*7",
+                "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "intron 13",
+                "endLocation": "intron 13",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "12362047",
+                        "referenceText": "Kurzawski et al., 2002"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 22
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 21
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 17
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                },
+                "mutationOrigin": "germline"
+            },
+            {
+                "variant": "2:g.47708011G>A",
+                "genomicLocation": "2,47708011,47708011,G,A",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.X878_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.G820Afs*2",
+                "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "intron 15",
+                "endLocation": "intron 15",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "12362047",
+                        "referenceText": "Kurzawski et al., 2002"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 22
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 21
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 17
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                },
+                "mutationOrigin": "germline"
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "RB1",
+        "transcriptId": "ENST00000267163",
+        "genomicLocationDescription": "c.1206C>T mutation on exon 12",
+        "defaultEffect": "synonymous",
+        "comment": "Disrupting the splicing enhancer element and caused skipping of exon 12",
+        "context": "Reported in an individual with unilateral retinoblastoma",
+        "revisedProteinEffects": [
+            {
+                "variant": "13:g.48947619C>T",
+                "genomicLocation": "13,48947619,48947619,C,T",
+                "transcriptId": "ENST00000267163",
+                "vepPredictedProteinEffect": "p.S402=",
+                "vepPredictedVariantClassification": "Silent",
+                "revisedProteinEffect": "p.R376Rfs*4",
+                "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "startLocation": "exon 12",
+                "endLocation": "exon 12",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21763628",
+                        "referenceText": "Ahani et al., 2011"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 180
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 32
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 156
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 0
+                    }
+                },
+                "variantNote": "This heterozygous RB1 c.1206C>T variant is a synonymous variant that does not alter the amino acid at this position (p.Ser402=). This variant has been identified in 3/30442 South Asian chromosomes by the Genome Aggregation Database (gnomAD: http://gnomad.broadinstitute.org). It has been reported in an individual with unilateral retinoblastoma and was demonstrated to cause abnormal splicing based on patient RNA studies (PMID 21763628). In our patient (DMG19-4863) with unilateral retinoblastoma, tumor analysis identified somatic biallelic mutations (two somatic hits) in RB1 (DMG internal data). In summary, based on the currently available data, the clinical significance of the RB1 c.1206C>T (p.Ser402=) variant is uncertain."
             }
         ]
     }

--- a/VUEs.json
+++ b/VUEs.json
@@ -14,10 +14,9 @@
                 "vepPredictedProteinEffect": "p.X550_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.K550_K558del",
-                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 10",
-                "endLocation": "exon 11",
+                "hgvsc": "ENST00000288135.5:c.1648-6_1672del",
                 "confirmed": true,
                 "references": [
                     {
@@ -63,10 +62,9 @@
                 "vepPredictedProteinEffect": "p.X550_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.K550_K558del",
-                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 10",
-                "endLocation": "exon 11",
+                "hgvsc": "ENST00000288135.5:c.1648_1674del",
                 "confirmed": true,
                 "references": [
                     {
@@ -112,10 +110,9 @@
                 "vepPredictedProteinEffect": "p.X550_splice",
                 "vepPredictedVariantClassification": "Splice_Site",
                 "revisedProteinEffect": "p.K550_K558del",
-                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 10",
-                "endLocation": "exon 11",
+                "hgvsc": "ENST00000288135.5:c.1648-3_1673del",
                 "confirmed": true,
                 "references": [
                     {
@@ -173,8 +170,7 @@
                 "revisedProteinEffect": "p.G279Ffs*10",
                 "revisedVariantClassification": "Splice_Exon_Extension_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Ins",
-                "startLocation": "intron 8",
-                "endLocation": "intron 8",
+                "hgvsc": "ENST00000257430.4:c.835-8A>G",
                 "confirmed": true,
                 "references": [
                     {
@@ -232,8 +228,7 @@
                 "revisedProteinEffect": "p.D311Gfs*23",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "exon 11",
-                "endLocation": "exon 11",
+                "hgvsc": "ENST00000460680.1:c.936T>C",
                 "confirmed": false,
                 "references": [
                     {
@@ -291,8 +286,7 @@
                 "revisedProteinEffect": "p.X61",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "exon 3",
-                "endLocation": "exon 3",
+                "hgvsc": "ENST00000256078.4:c.181C>A",
                 "confirmed": false,
                 "references": [
                     {
@@ -350,8 +344,7 @@
                 "revisedProteinEffect": "p.Q28_D81del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 3",
-                "endLocation": "intron 3",
+                "hgvsc": "ENST00000349496.5:c.86_241+63del",
                 "confirmed": true,
                 "references": [
                     {
@@ -399,8 +392,7 @@
                 "revisedProteinEffect": "p.A5_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 2",
-                "endLocation": "intron 3",
+                "hgvsc": "ENST00000349496.5:c.14-1_241+72del",
                 "confirmed": true,
                 "references": [
                     {
@@ -448,8 +440,7 @@
                 "revisedProteinEffect": "p.M12_D81del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 3",
-                "endLocation": "intron 3",
+                "hgvsc": "ENST00000349496.5:c.37_241+22del",
                 "confirmed": true,
                 "references": [
                     {
@@ -497,8 +488,7 @@
                 "revisedProteinEffect": "p.A5_Q72del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 2",
-                "endLocation": "exon 3",
+                "hgvsc": "ENST00000349496.5:c.13+141_220del",
                 "confirmed": true,
                 "references": [
                     {
@@ -546,8 +536,7 @@
                 "revisedProteinEffect": "p.S29_D81del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 3",
-                "endLocation": "intron 3",
+                "hgvsc": "ENST00000349496.5:c.90_241+12del",
                 "confirmed": true,
                 "references": [
                     {
@@ -595,8 +584,7 @@
                 "revisedProteinEffect": "p.A5_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 2",
-                "endLocation": "intron 3",
+                "hgvsc": "ENST00000349496.5:c.13+11_241+37del",
                 "confirmed": true,
                 "references": [
                     {
@@ -644,8 +632,7 @@
                 "revisedProteinEffect": "p.A5_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 2",
-                "endLocation": "intron 3",
+                "hgvsc": "ENST00000349496.5:c.13+152_241+11del",
                 "confirmed": true,
                 "references": [
                     {
@@ -693,8 +680,7 @@
                 "revisedProteinEffect": "p.E9_D81del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 3",
-                "endLocation": "intron 3",
+                "hgvsc": "ENST00000349496.5:c.30_241+47del",
                 "confirmed": true,
                 "references": [
                     {
@@ -742,8 +728,7 @@
                 "revisedProteinEffect": "p.E9_D81del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 3",
-                "endLocation": "intron 3",
+                "hgvsc": "ENST00000349496.5:c.29_242-21del",
                 "confirmed": true,
                 "references": [
                     {
@@ -791,8 +776,7 @@
                 "revisedProteinEffect": "p.A5_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 2",
-                "endLocation": "intron 3",
+                "hgvsc": "ENST00000349496.5:c.18_242-37del",
                 "confirmed": true,
                 "references": [
                     {
@@ -840,8 +824,7 @@
                 "revisedProteinEffect": "p.A5_G69del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 2",
-                "endLocation": "exon 3",
+                "hgvsc": "ENST00000349496.5:c.14-42_208del",
                 "confirmed": true,
                 "references": [
                     {
@@ -889,8 +872,7 @@
                 "revisedProteinEffect": "p.A5_Q79del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 2",
-                "endLocation": "exon 3",
+                "hgvsc": "ENST00000349496.5:c.14-109_233del",
                 "confirmed": true,
                 "references": [
                     {
@@ -938,8 +920,7 @@
                 "revisedProteinEffect": "p.A5_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 2",
-                "endLocation": "intron 3",
+                "hgvsc": "ENST00000349496.5:c.15_242-85del",
                 "confirmed": true,
                 "references": [
                     {
@@ -987,8 +968,7 @@
                 "revisedProteinEffect": "p.A5_Q72del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 2",
-                "endLocation": "exon 3",
+                "hgvsc": "ENST00000349496.5:c.14-117_218del",
                 "confirmed": true,
                 "references": [
                     {
@@ -1036,8 +1016,7 @@
                 "revisedProteinEffect": "p.A5_E9del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 2",
-                "endLocation": "exon 3",
+                "hgvsc": "ENST00000349496.5:c.14-12_29del",
                 "confirmed": true,
                 "references": [
                     {
@@ -1085,8 +1064,7 @@
                 "revisedProteinEffect": "p.A2_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 2",
-                "endLocation": "intron 3",
+                "hgvsc": "ENST00000349496.5:c.3_241+16del",
                 "confirmed": true,
                 "references": [
                     {
@@ -1134,8 +1112,7 @@
                 "revisedProteinEffect": "p.Q4_D81del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 2",
-                "endLocation": "intron 3",
+                "hgvsc": "ENST00000349496.5:c.9_241+22del",
                 "confirmed": true,
                 "references": [
                     {
@@ -1183,8 +1160,7 @@
                 "revisedProteinEffect": "p.A5_Q68del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 2",
-                "endLocation": "exon 3",
+                "hgvsc": "ENST00000349496.5:c.12_203del",
                 "confirmed": true,
                 "references": [
                     {
@@ -1232,8 +1208,7 @@
                 "revisedProteinEffect": "p.A5_A97del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 2",
-                "endLocation": "exon 4",
+                "hgvsc": "ENST00000349496.5:c.13+76_290del",
                 "confirmed": true,
                 "references": [
                     {
@@ -1281,8 +1256,7 @@
                 "revisedProteinEffect": "p.A5_F70del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 2",
-                "endLocation": "exon 3",
+                "hgvsc": "ENST00000349496.5:c.13+104_211del",
                 "confirmed": true,
                 "references": [
                     {
@@ -1330,8 +1304,7 @@
                 "revisedProteinEffect": "p.A5_Q68del",
                 "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 2",
-                "endLocation": "exon 3",
+                "hgvsc": "ENST00000349496.5:c.14-27_201del",
                 "confirmed": true,
                 "references": [
                     {
@@ -1389,8 +1362,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 14",
-                "endLocation": "intron 14",
+                "hgvsc": "ENST00000397752.3:c.2914_3028+43del",
                 "confirmed": false,
                 "references": [
                     {
@@ -1438,8 +1410,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 13",
-                "endLocation": "intron 14",
+                "hgvsc": "ENST00000397752.3:c.2887+62_3028+306del",
                 "confirmed": false,
                 "references": [
                     {
@@ -1487,8 +1458,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 13",
-                "endLocation": "intron 14",
+                "hgvsc": "ENST00000397752.3:c.2888-79_3028+520del",
                 "confirmed": false,
                 "references": [
                     {
@@ -1536,8 +1506,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 13",
-                "endLocation": "intron 13",
+                "hgvsc": "ENST00000397752.3:c.2888-29_2888-6del",
                 "confirmed": false,
                 "references": [
                     {
@@ -1585,8 +1554,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 13",
-                "endLocation": "intron 13",
+                "hgvsc": "ENST00000397752.3:c.2888-22_2888-6del",
                 "confirmed": false,
                 "references": [
                     {
@@ -1634,8 +1602,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 13",
-                "endLocation": "exon 14",
+                "hgvsc": "ENST00000397752.3:c.2888-22_2922del",
                 "confirmed": false,
                 "references": [
                     {
@@ -1683,8 +1650,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 13",
-                "endLocation": "intron 13",
+                "hgvsc": "ENST00000397752.3:c.2888-43_2888-15del",
                 "confirmed": false,
                 "references": [
                     {
@@ -1732,8 +1698,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 13",
-                "endLocation": "intron 13",
+                "hgvsc": "ENST00000397752.3:c.2888-24_2888-7del",
                 "confirmed": false,
                 "references": [
                     {
@@ -1781,8 +1746,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 14",
-                "endLocation": "intron 14",
+                "hgvsc": "ENST00000397752.3:c.3028+3A>G",
                 "confirmed": false,
                 "references": [
                     {
@@ -1830,8 +1794,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 13",
-                "endLocation": "intron 13",
+                "hgvsc": "ENST00000397752.3:c.2888-24_2888-6del",
                 "confirmed": false,
                 "references": [
                     {
@@ -1879,8 +1842,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 13",
-                "endLocation": "exon 14",
+                "hgvsc": "ENST00000397752.3:c.2888-16_2891del",
                 "confirmed": false,
                 "references": [
                     {
@@ -1928,8 +1890,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 14",
-                "endLocation": "exon 14",
+                "hgvsc": "ENST00000397752.3:c.3028G>A",
                 "confirmed": false,
                 "references": [
                     {
@@ -1977,8 +1938,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 13",
-                "endLocation": "intron 13",
+                "hgvsc": "ENST00000397752.3:c.2888-18_2888-6del",
                 "confirmed": false,
                 "references": [
                     {
@@ -2026,8 +1986,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 14",
-                "endLocation": "intron 14",
+                "hgvsc": "ENST00000397752.3:c.3026_3028+1del",
                 "confirmed": false,
                 "references": [
                     {
@@ -2075,8 +2034,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 13",
-                "endLocation": "intron 13",
+                "hgvsc": "ENST00000397752.3:c.2888-22_2888-8del",
                 "confirmed": false,
                 "references": [
                     {
@@ -2124,8 +2082,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 13",
-                "endLocation": "intron 13",
+                "hgvsc": "ENST00000397752.3:c.2888-36_2888-21del",
                 "confirmed": false,
                 "references": [
                     {
@@ -2173,8 +2130,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 14",
-                "endLocation": "intron 14",
+                "hgvsc": "ENST00000397752.3:c.3028+1G>A",
                 "confirmed": false,
                 "references": [
                     {
@@ -2222,8 +2178,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 13",
-                "endLocation": "intron 13",
+                "hgvsc": "ENST00000397752.3:c.2888-27_2888-7del",
                 "confirmed": false,
                 "references": [
                     {
@@ -2271,8 +2226,7 @@
                 "revisedProteinEffect": "p.D963_D1010del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 13",
-                "endLocation": "intron 13",
+                "hgvsc": "ENST00000397752.3:c.2888-36_2888-13del",
                 "confirmed": false,
                 "references": [
                     {
@@ -2330,8 +2284,7 @@
                 "revisedProteinEffect": "p.D434_E476del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 11",
-                "endLocation": "intron 11",
+                "hgvsc": "ENST00000521381.1:c.1425+1G>C",
                 "confirmed": false,
                 "references": [
                     {
@@ -2389,8 +2342,7 @@
                 "revisedProteinEffect": "p.E598_F612dup",
                 "revisedVariantClassification": "Splice_Exon_Extension_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Ins",
-                "startLocation": "intron 13",
-                "endLocation": "intron 13",
+                "hgvsc": "ENST00000241453.7:c.1782_1837+1dup",
                 "confirmed": false,
                 "references": [
                     {
@@ -2448,8 +2400,7 @@
                 "revisedProteinEffect": "p.C222Qfs*2",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "exon 7",
-                "endLocation": "exon 7",
+                "hgvsc": "ENST00000278616.4:c.901G>A",
                 "confirmed": false,
                 "references": [
                     {
@@ -2498,8 +2449,7 @@
                 "revisedProteinEffect": "p.I709_K750del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 14",
-                "endLocation": "exon 14",
+                "hgvsc": "ENST00000278616.4:c.2250G>A",
                 "confirmed": true,
                 "references": [
                     {
@@ -2553,8 +2503,7 @@
                 "revisedProteinEffect": "p.A823Vfs*5",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "intron 17",
-                "endLocation": "intron 17",
+                "hgvsc": "ENST00000278616.4:c.2638+2T>C",
                 "confirmed": false,
                 "references": [
                     {
@@ -2603,8 +2552,7 @@
                 "revisedProteinEffect": "p.V1833Ifs*63",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "intron 36",
-                "endLocation": "intron 36",
+                "hgvsc": "ENST00000278616.4:c.5497-2A>C",
                 "confirmed": false,
                 "references": [
                     {
@@ -2653,8 +2601,7 @@
                 "revisedProteinEffect": "p.N2326_K2363del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 47",
-                "endLocation": "intron 47",
+                "hgvsc": "ENST00000278616.4:c.6976-2A>C",
                 "confirmed": false,
                 "references": [
                     {
@@ -2703,8 +2650,7 @@
                 "revisedProteinEffect": "p.N2326_K2363del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 48",
-                "endLocation": "intron 48",
+                "hgvsc": "ENST00000278616.4:c.7088_7089+37del",
                 "confirmed": false,
                 "references": [
                     {
@@ -2753,8 +2699,7 @@
                 "revisedProteinEffect": "p.V2757_M2806del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 57",
-                "endLocation": "intron 57",
+                "hgvsc": "ENST00000278616.4:c.8418+1_8418+5del",
                 "confirmed": false,
                 "references": [
                     {
@@ -2803,8 +2748,7 @@
                 "revisedProteinEffect": "p.S2996Rfs*5",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "intron 62",
-                "endLocation": "intron 62",
+                "hgvsc": "ENST00000278616.4:c.8988-1G>A",
                 "confirmed": false,
                 "references": [
                     {
@@ -2853,8 +2797,7 @@
                 "revisedProteinEffect": "p.L2544_E2596del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 52",
-                "endLocation": "exon 52",
+                "hgvsc": "ENST00000278616.4:c.7788G>A",
                 "confirmed": true,
                 "references": [
                     {
@@ -2904,8 +2847,7 @@
                 "revisedProteinEffect": "p.S1135_K1192",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 24",
-                "endLocation": "exon 24",
+                "hgvsc": "ENST00000278616.4:c.3576G>A",
                 "confirmed": true,
                 "references": [
                     {
@@ -2973,8 +2915,7 @@
                 "revisedProteinEffect": "p.A1844Dfs*2",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "intron 21",
-                "endLocation": "intron 21",
+                "hgvsc": "ENST00000357654.3:c.5468-1G>A",
                 "confirmed": false,
                 "references": [
                     {
@@ -3023,8 +2964,7 @@
                 "revisedProteinEffect": "p.A1453Gfs*9",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "exon 13",
-                "endLocation": "exon 13",
+                "hgvsc": "ENST00000357654.3:c.4484G>T",
                 "confirmed": false,
                 "references": [
                     {
@@ -3083,8 +3023,7 @@
                 "revisedProteinEffect": "p.G173Sfs*17",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "intron 6",
-                "endLocation": "intron 6",
+                "hgvsc": "ENST00000380152.3:c.517-2A>G",
                 "confirmed": false,
                 "references": [
                     {
@@ -3133,8 +3072,7 @@
                 "revisedProteinEffect": "p.L2540Qfs*10",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "intron 15",
-                "endLocation": "intron 15",
+                "hgvsc": "ENST00000380152.3:c.7618-1G>A",
                 "confirmed": false,
                 "references": [
                     {
@@ -3183,8 +3121,7 @@
                 "revisedProteinEffect": "p.V2985Gfs*3",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "exon 23",
-                "endLocation": "exon 23",
+                "hgvsc": "ENST00000380152.3:c.9117G>A",
                 "confirmed": false,
                 "references": [
                     {
@@ -3223,6 +3160,54 @@
                     }
                 },
                 "mutationOrigin": "germline"
+            },
+            {
+                "variant": "13:g.32919384T>G",
+                "genomicLocation": "13,32919384,32919384,T,G",
+                "transcriptId": "ENST00000380152",
+                "vepPredictedProteinEffect": NaN,
+                "vepPredictedVariantClassification": "Intron",
+                "revisedProteinEffect": "p.G2313Gfs*9",
+                "revisedVariantClassification": "Splice_Exon_Extension_Out_Of_Frame",
+                "revisedStandardVariantClassification": "Frame_Shift_Ins",
+                "hgvsc": "ENST00000380152.3:c.6937+594T>G",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "22753590",
+                        "referenceText": "Anczuk\u00c2\u0097w  et al., 2012"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 587
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 221
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 532
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 1
+                    }
+                }
             }
         ]
     },
@@ -3243,8 +3228,7 @@
                 "revisedProteinEffect": "p.D127Dfs*1",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "exon 5",
-                "endLocation": "exon 5",
+                "hgvsc": "ENST00000259008.2:c.507G>A",
                 "confirmed": true,
                 "references": [
                     {
@@ -3294,8 +3278,7 @@
                 "revisedProteinEffect": "p.M1_S31del",
                 "revisedVariantClassification": "Splice_Exon_Skip_Non_Start",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 1",
-                "endLocation": "intron 1",
+                "hgvsc": "ENST00000259008.2:c.93+1G>A",
                 "confirmed": false,
                 "references": [
                     {
@@ -3354,8 +3337,7 @@
                 "revisedProteinEffect": "p.T523*",
                 "revisedVariantClassification": "Splice_Exon_Extension_Nonsense",
                 "revisedStandardVariantClassification": "Nonsense_Mutation",
-                "startLocation": "intron 10",
-                "endLocation": "intron 10",
+                "hgvsc": "ENST00000261769.5:c.1565+1G>A",
                 "confirmed": false,
                 "references": [
                     {
@@ -3404,8 +3386,7 @@
                 "revisedProteinEffect": "p.Y523Ffs*15",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "exon 11",
-                "endLocation": "exon 11",
+                "hgvsc": "ENST00000261769.5:c.1711G>A",
                 "confirmed": false,
                 "references": [
                     {
@@ -3454,8 +3435,7 @@
                 "revisedProteinEffect": "p.S337Vfs*14",
                 "revisedVariantClassification": "Splice_Exon_Extension_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Ins",
-                "startLocation": "exon 7",
-                "endLocation": "exon 7",
+                "hgvsc": "ENST00000261769.5:c.1008G>A",
                 "confirmed": false,
                 "references": [
                     {
@@ -3519,8 +3499,7 @@
                 "revisedProteinEffect": "p.E149Ifs*5",
                 "revisedVariantClassification": "Splice_Exon_Extension_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Ins",
-                "startLocation": "intron 2",
-                "endLocation": "intron 2",
+                "hgvsc": "ENST00000328354.6:c.444+1G>A",
                 "confirmed": false,
                 "references": [
                     {
@@ -3579,8 +3558,7 @@
                 "revisedProteinEffect": "p.A946_G999del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 7",
-                "endLocation": "intron 7",
+                "hgvsc": "ENST00000261584.4:c.2835-1G>C",
                 "confirmed": false,
                 "references": [
                     {
@@ -3629,8 +3607,7 @@
                 "revisedProteinEffect": "p.T839_K862del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 4",
-                "endLocation": "intron 4",
+                "hgvsc": "ENST00000261584.4:c.2515-1G>T",
                 "confirmed": false,
                 "references": [
                     {
@@ -3689,8 +3666,7 @@
                 "revisedProteinEffect": "p.P322Vfs*5",
                 "revisedVariantClassification": "Splice_Exon_Shortening_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "intron 8",
-                "endLocation": "intron 8",
+                "hgvsc": "ENST00000590016.1:c.964-2A>T",
                 "confirmed": false,
                 "references": [
                     {
@@ -3749,8 +3725,7 @@
                 "revisedProteinEffect": "p.S556Rfs*13",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "exon 15",
-                "endLocation": "exon 15",
+                "hgvsc": "ENST00000231790.2:c.1731G>A",
                 "confirmed": true,
                 "references": [
                     {
@@ -3808,8 +3783,7 @@
                 "revisedProteinEffect": "p.H264Lfs*2",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "exon 10",
-                "endLocation": "exon 10",
+                "hgvsc": "ENST00000231790.2:c.842C>T",
                 "confirmed": false,
                 "references": [
                     {
@@ -3858,8 +3832,7 @@
                 "revisedProteinEffect": "p.E633_E663del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 17",
-                "endLocation": "exon 17",
+                "hgvsc": "ENST00000231790.2:c.1976G>C",
                 "confirmed": false,
                 "references": [
                     {
@@ -3908,8 +3881,7 @@
                 "revisedProteinEffect": "p.G181Gfs*20",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "exon 6",
-                "endLocation": "exon 6",
+                "hgvsc": "ENST00000231790.2:c.543C>T",
                 "confirmed": false,
                 "references": [
                     {
@@ -3958,8 +3930,7 @@
                 "revisedProteinEffect": "p.R84Sfs*5",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "intron 6",
-                "endLocation": "intron 6",
+                "hgvsc": "ENST00000231790.2:c.546-2A>G",
                 "confirmed": false,
                 "references": [
                     {
@@ -4008,8 +3979,7 @@
                 "revisedProteinEffect": "p.Q197Rfs*7",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "exon 8",
-                "endLocation": "exon 8",
+                "hgvsc": "ENST00000231790.2:c.677G>T",
                 "confirmed": false,
                 "references": [
                     {
@@ -4062,8 +4032,7 @@
                 "revisedProteinEffect": "p.H264Lfs*1",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "exon 10",
-                "endLocation": "exon 10",
+                "hgvsc": "ENST00000231790.2:c.883A>C",
                 "confirmed": false,
                 "references": [
                     {
@@ -4116,8 +4085,7 @@
                 "revisedProteinEffect": "p.T347Kfs*7",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "intron 12",
-                "endLocation": "intron 12",
+                "hgvsc": "ENST00000231790.2:c.1409+1G>C",
                 "confirmed": false,
                 "references": [
                     {
@@ -4180,8 +4148,7 @@
                 "revisedProteinEffect": "p.A763_Y764insFQEA",
                 "revisedVariantClassification": "Splice_Exon_Extension_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Ins",
-                "startLocation": "intron 19",
-                "endLocation": "intron 19",
+                "hgvsc": "ENST00000275493.2:c.2284-5_2290dup",
                 "confirmed": true,
                 "references": [
                     {
@@ -4239,8 +4206,7 @@
                 "revisedProteinEffect": "p.S33_T125del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 3",
-                "endLocation": "intron 3",
+                "hgvsc": "ENST00000269305.4:c.375+5G>T",
                 "confirmed": true,
                 "references": [
                     {
@@ -4289,8 +4255,7 @@
                 "revisedProteinEffect": "p.S33_T125del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 4",
-                "endLocation": "exon 4",
+                "hgvsc": "ENST00000269305.4:c.375G>T",
                 "confirmed": true,
                 "references": [
                     {
@@ -4350,8 +4315,7 @@
                 "revisedProteinEffect": "p.D526_G572del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 14",
-                "endLocation": "exon 14",
+                "hgvsc": "ENST00000403665.2:c.1693G>A",
                 "confirmed": false,
                 "references": [
                     {
@@ -4399,8 +4363,7 @@
                 "revisedProteinEffect": "p.K343_E379del",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "exon 10",
-                "endLocation": "exon 10",
+                "hgvsc": "ENST00000403665.2:c.1060G>A",
                 "confirmed": false,
                 "references": [
                     {
@@ -4448,8 +4411,7 @@
                 "revisedProteinEffect": "p.A199_R252del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 7",
-                "endLocation": "exon 7",
+                "hgvsc": "ENST00000403665.2:c.616C>T",
                 "confirmed": false,
                 "references": [
                     {
@@ -4507,8 +4469,7 @@
                 "revisedProteinEffect": "p.V265_Q314del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 5",
-                "endLocation": "exon 5",
+                "hgvsc": "ENST00000233146.2:c.806C>T",
                 "confirmed": false,
                 "references": [
                     {
@@ -4556,8 +4517,7 @@
                 "revisedProteinEffect": "p.V265_Q314del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "exon 5",
-                "endLocation": "exon 5",
+                "hgvsc": "ENST00000233146.2:c.815C>T",
                 "confirmed": false,
                 "references": [
                     {
@@ -4605,8 +4565,7 @@
                 "revisedProteinEffect": "p.G504Afs*3",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "exon 10",
-                "endLocation": "exon 10",
+                "hgvsc": "ENST00000233146.2:c.1516G>T",
                 "confirmed": false,
                 "references": [
                     {
@@ -4654,8 +4613,7 @@
                 "revisedProteinEffect": "p.G504Afs*3",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "exon 10",
-                "endLocation": "exon 10",
+                "hgvsc": "ENST00000233146.2:c.1600C>T",
                 "confirmed": false,
                 "references": [
                     {
@@ -4703,8 +4661,7 @@
                 "revisedProteinEffect": "p.V265_Q314del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 5",
-                "endLocation": "intron 5",
+                "hgvsc": "ENST00000233146.2:c.942+3A>T",
                 "confirmed": false,
                 "references": [
                     {
@@ -4761,8 +4718,7 @@
                 "revisedProteinEffect": "p.G504Afs*3",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "intron 10",
-                "endLocation": "intron 10",
+                "hgvsc": "ENST00000233146.2:c.1661+5G>C",
                 "confirmed": false,
                 "references": [
                     {
@@ -4819,8 +4775,7 @@
                 "revisedProteinEffect": "p.A123_Q215del",
                 "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
                 "revisedStandardVariantClassification": "In_Frame_Del",
-                "startLocation": "intron 3",
-                "endLocation": "intron 3",
+                "hgvsc": "ENST00000233146.2:c.645+1G>T",
                 "confirmed": false,
                 "references": [
                     {
@@ -4873,8 +4828,7 @@
                 "revisedProteinEffect": "p.G669Gfs*7",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "intron 13",
-                "endLocation": "intron 13",
+                "hgvsc": "ENST00000233146.2:c.2210+1G>C",
                 "confirmed": false,
                 "references": [
                     {
@@ -4927,8 +4881,7 @@
                 "revisedProteinEffect": "p.G820Afs*2",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "intron 15",
-                "endLocation": "intron 15",
+                "hgvsc": "ENST00000233146.2:c.2634+1G>A",
                 "confirmed": false,
                 "references": [
                     {
@@ -4991,8 +4944,7 @@
                 "revisedProteinEffect": "p.R376Rfs*4",
                 "revisedVariantClassification": "Splice_Exon_Skip_Out_Of_Frame",
                 "revisedStandardVariantClassification": "Frame_Shift_Del",
-                "startLocation": "exon 12",
-                "endLocation": "exon 12",
+                "hgvsc": "ENST00000267163.4:c.1206C>T",
                 "confirmed": false,
                 "references": [
                     {


### PR DESCRIPTION
- 6 new paper curated ([Oldfield 2021](https://pubmed.ncbi.nlm.nih.gov/33259954/), [Kurzawski 2002](https://pubmed.ncbi.nlm.nih.gov/12362047/), [Kurzawski 2002](https://pubmed.ncbi.nlm.nih.gov/16451135/), [Anczuków 2012](https://pubmed.ncbi.nlm.nih.gov/22753590), oncokb germline spreadsheet (RB1 and CDH1))
- 12 new reVUE variants added, 1 existing variant updated
    - MSH2: 5
    - MLH1: 5
    - BRCA2: 1
    - Rb1: 1
    - CDH1: 1
- New field in json: 
    - `hgvsc` added for all variants
    - `revisedStandardVariantClassification` added for all variants