### PR TITLE
Bring back VUEs.json for older versions of Genome Nexus

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ For each gene:
         - totalPatientCount (integer)
         - genePatientCount (integer)
 
+## File Hierarchy
+Starting from version v1.4.3, Genome Nexus uses the new `./generated/VUEs.json` file to store VUE data. For compatibility with older versions, the previous file, `./VUEs.json`, is still retained. However, please note the following:
+
+- `./generated/VUEs.json`:
+    - Contains the latest reVUE data.
+    - Actively maintained and updated with new information.
+
+- `./VUEs.json`:
+    - Used by Genome Nexus versions prior to v1.4.3.
+    - No longer maintained or updated.
+
+Both files are kept in the repository to ensure support for all versions of Genome Nexus. However, all future updates will be made exclusively to ./generated/VUEs.json. Users are encouraged to upgrade to v1.4.3 or later to benefit from the latest data.
+
 ## VUE updating process
 #### Submit potential VUEs
 

--- a/VUEs.json
+++ b/VUEs.json
@@ -1,0 +1,7341 @@
+[
+    {
+        "hugoGeneSymbol": "KIT",
+        "transcriptId": "ENST00000288135",
+        "genomicLocationDescription": "Deletions flanking intron 10 - exon 11 boundary (e.g. 4:55593576_55593606del)",
+        "defaultEffect": "splice",
+        "comment": "Changes splice donor site, cause inframe deletion in exon 11",
+        "context": "Actionable in GIST",
+        "revisedProteinEffects": [
+            {
+                "variant": "4:g.55593576_55593606del",
+                "genomicLocation": "4,55593576,55593606,CCACAGAAACCCATGTATGAAGTACAGTGGA,-",
+                "transcriptId": "ENST00000288135",
+                "vepPredictedProteinEffect": "p.X550_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.K550_K558del",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000288135.5:c.1648-6_1672del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "15507676",
+                        "referenceText": "Corless et al., 2004"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 3,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Gastrointestinal Stromal Tumor": 3
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1884
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 334
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 3,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Gastrointestinal Stromal Tumor": 3
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1594
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6581
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "4:g.55593580_55593606del",
+                "genomicLocation": "4,55593580,55593606,AGAAACCCATGTATGAAGTACAGTGGA,-",
+                "transcriptId": "ENST00000288135",
+                "vepPredictedProteinEffect": "p.X550_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.K550_K558del",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000288135.5:c.1648_1674del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "15507676",
+                        "referenceText": "Corless et al., 2004"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 5,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Gastrointestinal Stromal Tumor": 5
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1884
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 334
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 5,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Gastrointestinal Stromal Tumor": 5
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1594
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6581
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "4:g.55593578_55593606del",
+                "genomicLocation": "4,55593578,55593606,ACAGAAACCCATGTATGAAGTACAGTGGA,-",
+                "transcriptId": "ENST00000288135",
+                "vepPredictedProteinEffect": "p.X550_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.K550_K558del",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000288135.5:c.1648-3_1673del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "15507676",
+                        "referenceText": "Corless et al., 2004"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 3,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Gastrointestinal Stromal Tumor": 3
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1884
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 334
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 3,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Gastrointestinal Stromal Tumor": 3
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1594
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6581
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "APC",
+        "transcriptId": "ENST00000257430",
+        "genomicLocationDescription": "5:g.112151184A>G",
+        "defaultEffect": "splice",
+        "comment": "Introduces splice acceptor site causing a frameshift",
+        "context": "Recurrent alteration in CRC",
+        "revisedProteinEffects": [
+            {
+                "variant": "5:g.112151184A>G",
+                "genomicLocation": "5,112151184,112151184,A,G",
+                "transcriptId": "ENST00000257430",
+                "vepPredictedProteinEffect": "p.*279*",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.G279Ffs*10",
+                "revisedVariantClassification": "Splice_Exon_Extension_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Ins",
+                "hgvsc": "ENST00000257430.4:c.835-8A>G",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 1,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 8570
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 852
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 6954
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 321,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 316,
+                            "Tubular Adenoma of the Colon": 4,
+                            "Non-Small Cell Lung Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6116
+                    }
+                },
+                "therapeuticLevel": null
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "BAP1",
+        "transcriptId": "ENST00000460680",
+        "genomicLocationDescription": "3:g.52439306A>G",
+        "defaultEffect": "synonymous",
+        "comment": "Leads to exon 11 skipping",
+        "context": "Recurrent and prognostic in kidney cancer",
+        "revisedProteinEffects": [
+            {
+                "variant": "3:g.52439306A>G",
+                "genomicLocation": "3,52439306,52439306,A,G",
+                "transcriptId": "ENST00000460680",
+                "vepPredictedProteinEffect": "p.G312=",
+                "vepPredictedVariantClassification": "Silent",
+                "revisedProteinEffect": "p.D311Gfs*23",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000460680.1:c.936T>C",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "33681728",
+                        "referenceText": "Niersch et al., 2021"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1670
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 279
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1439
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2509
+                    }
+                },
+                "therapeuticLevel": null
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "KRAS",
+        "transcriptId": "ENST00000256078",
+        "genomicLocationDescription": "12:g.25380277G>T",
+        "defaultEffect": "missense",
+        "comment": "Introduces a splice donor site if Q61K is not co-occurring with G60G",
+        "context": "Recurrent in many cancer types",
+        "revisedProteinEffects": [
+            {
+                "variant": "12:g.25380277G>T",
+                "genomicLocation": "12,25380277,25380277,G,T",
+                "transcriptId": "ENST00000256078",
+                "vepPredictedProteinEffect": "p.Q61K",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.X61",
+                "revisedVariantClassification": "Splice_Exon_Shortening_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000256078.4:c.181C>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "35236983",
+                        "referenceText": "Kobayashi et al., 2022"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 7,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Pancreatic Cancer": 1,
+                            "Gastrointestinal Neuroendocrine Tumor": 1,
+                            "Colorectal Cancer": 4,
+                            "Prostate Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 12456
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 7,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 806
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 7,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Prostate Cancer": 1,
+                            "Colorectal Cancer": 4,
+                            "Gastrointestinal Neuroendocrine Tumor": 1,
+                            "Pancreatic Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 10709
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5375
+                    }
+                },
+                "therapeuticLevel": "LEVEL_2"
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "CTNNB1",
+        "transcriptId": "ENST00000349496",
+        "genomicLocationDescription": "Deletions flanking exon 2-3 (e.g. 3:41265579_41266277del)",
+        "defaultEffect": "splice, intron",
+        "comment": "Complete exon 3 skip or inframe deletion in exon 3",
+        "context": "Recurrent alteration in CRC",
+        "revisedProteinEffects": [
+            {
+                "variant": "3:g.41266086_41266304del",
+                "genomicLocation": "3,41266086,41266304,AGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTGCCTTACTGAAAGTCAGAATGCAGTTTTGAGAACTAAAA,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X29_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.Q28_D81del",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.86_241+63del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41266012_41266312del",
+                "genomicLocation": "3,41266012,41266312,TATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTGCCTTACTGAAAGTCAGAATGCAGTTTTGAGAACTAAAAAGTTAGTG,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X5_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A5_D81del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.14-1_241+72del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41266038_41266264del",
+                "genomicLocation": "3,41266038,41266264,TGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCAT,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X13_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.M12_D81del",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.37_241+22del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41265709_41266219del",
+                "genomicLocation": "3,41265709,41266219,TCCTCCTAATGGCTTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAG,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X5_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A5_Q72del",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.13+141_220del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41266090_41266253del",
+                "genomicLocation": "3,41266090,41266253,TTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTA,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X30_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.S29_D81del",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.90_241+12del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41265579_41266277del",
+                "genomicLocation": "3,41265579,41266277,GTCATTAAATCTTTAGTTACTGAATTGGGGCTCTGCTTCGTTGCCATTAAGCCAGTCTGGCTGAGATCCCCCTGCTTTCCTCTCTCCCTGCTTACTTGTCAGGCTACCTTTTGCTCCATTTTCTGCTCACTCCTCCTAATGGCTTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTGCCTTACTGAAA,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X5_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A5_D81del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.13+11_241+37del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41265722_41266253del",
+                "genomicLocation": "3,41265722,41266253,TTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTA,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X5_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A5_D81del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.13+152_241+11del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41266029_41266287del",
+                "genomicLocation": "3,41266029,41266287,AGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTGCCTTACTGAAAGTCAGAATGC,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X10_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.E9_D81del",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.30_241+47del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41266028_41266420del",
+                "genomicLocation": "3,41266028,41266420,GAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTGCCTTACTGAAAGTCAGAATGCAGTTTTGAGAACTAAAAAGTTAGTGTATAATAGTTTAAATAAAATGTTGTGGTGAAGAAAAGAGAGTAATAGCAATGTCACTTTTACCATTTAGGATAGCAAATACTTAGGTAAATGCTGAACTGTGGATAGT,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X10_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.E9_D81del",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.29_242-21del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41266016_41266403del",
+                "genomicLocation": "3,41266016,41266403,GCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTGCCTTACTGAAAGTCAGAATGCAGTTTTGAGAACTAAAAAGTTAGTGTATAATAGTTTAAATAAAATGTTGTGGTGAAGAAAAGAGAGTAATAGCAATGTCACTTTTACCATTTAGGATAGCAAATACTTAGGTAAAT,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X6_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A5_D81del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.18_242-37del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41265975_41266211del",
+                "genomicLocation": "3,41265975,41266211,CATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGAT,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X5_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A5_G69del",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.14-42_208del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41265908_41266236del",
+                "genomicLocation": "3,41265908,41266236,TTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACA,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X5_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A5_Q79del",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.14-109_233del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41266013_41266355del",
+                "genomicLocation": "3,41266013,41266355,ATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTGCCTTACTGAAAGTCAGAATGCAGTTTTGAGAACTAAAAAGTTAGTGTATAATAGTTTAAATAAAATGTTGTGGTGAAGAAAAGAGAGTA,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X5_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A5_D81del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.15_242-85del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41265897_41266218del",
+                "genomicLocation": "3,41265897,41266218,GTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCA,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X5_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A5_Q72del",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.14-117_218del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41266002_41266029del",
+                "genomicLocation": "3,41266002,41266029,GTTTCGTATTTATAGCTGATTTGATGGA,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X5_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A5_E9del",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.14-12_29del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41265562_41266260del",
+                "genomicLocation": "3,41265562,41266260,GGCTACTCAAGGTTTGTGTCATTAAATCTTTAGTTACTGAATTGGGGCTCTGCTTCGTTGCCATTAAGCCAGTCTGGCTGAGATCCCCCTGCTTTCCTCTCTCCCTGCTTACTTGTCAGGCTACCTTTTGCTCCATTTTCTGCTCACTCCTCCTAATGGCTTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTT,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X1_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A2_D81del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.3_241+16del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41265568_41266266del",
+                "genomicLocation": "3,41265568,41266266,TCAAGGTTTGTGTCATTAAATCTTTAGTTACTGAATTGGGGCTCTGCTTCGTTGCCATTAAGCCAGTCTGGCTGAGATCCCCCTGCTTTCCTCTCTCCCTGCTTACTTGTCAGGCTACCTTTTGCTCCATTTTCTGCTCACTCCTCCTAATGGCTTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTG,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X3_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.Q4_D81del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.9_241+22del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41265571_41266206del",
+                "genomicLocation": "3,41265571,41266206,AGGTTTGTGTCATTAAATCTTTAGTTACTGAATTGGGGCTCTGCTTCGTTGCCATTAAGCCAGTCTGGCTGAGATCCCCCTGCTTTCCTCTCTCCCTGCTTACTTGTCAGGCTACCTTTTGCTCCATTTTCTGCTCACTCCTCCTAATGGCTTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACA,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X4_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A5_Q68del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.12_203del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41265648_41266493del",
+                "genomicLocation": "3,41265648,41266493,CCCTGCTTTCCTCTCTCCCTGCTTACTTGTCAGGCTACCTTTTGCTCCATTTTCTGCTCACTCCTCCTAATGGCTTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATTTTCTCAGTCCTTCACTCAAGAACAAGTAGCTGGTAAGAGTATTATTTTTCATTGCCTTACTGAAAGTCAGAATGCAGTTTTGAGAACTAAAAAGTTAGTGTATAATAGTTTAAATAAAATGTTGTGGTGAAGAAAAGAGAGTAATAGCAATGTCACTTTTACCATTTAGGATAGCAAATACTTAGGTAAATGCTGAACTGTGGATAGTGAGTGTTGAATTAACCTTTTCCAGATATTGATGGACAGTATGCAATGACTCGAGCTCAGAGGGTACGAGCTGC,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X5_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A5_A97del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.13+76_290del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41265674_41266212del",
+                "genomicLocation": "3,41265674,41266212,TTGTCAGGCTACCTTTTGCTCCATTTTCTGCTCACTCCTCCTAATGGCTTGGTGAAATAGCAAACAAGCCACCAGCAGGAATCTAGTCTGGATGACTGCTTCTGGAGCCTGGATGCAGTACCATTCTTCCACTGATTCAGTGAGTAACTGTTAGGTGGTTCCCTAAGGGATTAGGTATTTCATCACTGAGCTAACCCTGGCTATCATTCTGCTTTTCTTGGCTGTCTTTCAGATTTGACTTTATTTCTAAAAATATTTCAATGGGTCATATCACAGATTCTTTTTTTTTAAATTAAAGTAACATTTCCAATCTACTAATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAACAGGGATT,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X5_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A5_F70del",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.13+104_211del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.41265990_41266204del",
+                "genomicLocation": "3,41265990,41266204,AATGCTAATACTGTTTCGTATTTATAGCTGATTTGATGGAGTTGGACATGGCCATGGAACCAGACAGAAAAGCGGCTGTTAGTCACTGGCAGCAACAGTCTTACCTGGACTCTGGAATCCATTCTGGTGCCACTACCACAGCTCCTTCTCTGAGTGGTAAAGGCAATCCTGAGGAAGAGGATGTGGATACCTCCCAAGTCCTGTATGAGTGGGAA,-",
+                "transcriptId": "ENST00000349496",
+                "vepPredictedProteinEffect": "p.X5_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A5_Q68del",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000349496.5:c.14-27_201del",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29316426",
+                        "referenceText": "Yaeger et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2837
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 455
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2388
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2071
+                    }
+                },
+                "therapeuticLevel": null
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "MET",
+        "transcriptId": "ENST00000397752",
+        "genomicLocationDescription": "Indels and substitutions flanking exon 14 (e.g. 7:116411926_116412083del)",
+        "defaultEffect": "splice",
+        "comment": "Skipping of exon 14",
+        "context": "Actionable in NSCLC",
+        "revisedProteinEffects": [
+            {
+                "variant": "7:g.116411926_116412083del",
+                "genomicLocation": "7,116411926,116412083,TACGATGCAAGAGTACACACTCCTCATTTGGATAGGCTTGTAAGTGCCCGAAGTGTAAGCCCAACTACAGAAATGGTTTCAAATGAATCTGTAGACTACCGAGCTACTTTTCCAGAAGGTATATTTCAGTTTATTGTTCTGAGAAATACCTATACATA,-",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.X972_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.2914_3028+43del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "27343443",
+                        "referenceText": "Schrock et al., 2014"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Hepatobiliary Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Hepatobiliary Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "7:g.116411770_116412349del",
+                "genomicLocation": "7,116411770,116412349,AGATTGTCGTCGATTCTTGTGTGCTGTCTTATATGTAGTCCATAAAACCCATGAGTTCTGGGCACTGGGTCAAAGTCTCCTGGGGCCCATGATAGCCGTCTTTAACAAGCTCTTTCTTTCTCTCTGTTTTAAGATCTGGGCAGTGAATTAGTTCGCTACGATGCAAGAGTACACACTCCTCATTTGGATAGGCTTGTAAGTGCCCGAAGTGTAAGCCCAACTACAGAAATGGTTTCAAATGAATCTGTAGACTACCGAGCTACTTTTCCAGAAGGTATATTTCAGTTTATTGTTCTGAGAAATACCTATACATATACCTCAGTGGGTTGTGACATTGTTGTTTATTTTTGGTTTTGCATTTATATTTTTATAAAAACCTAAAGGAAGTATTTACCTCTGCCAAGTAAGTATTTGACACAAAATTACATGGCTCTTAATTTTAAAAGAACCCATGTATATATTACATTATGATTTTAGAGTCCATAAGCTCTCATTTCACAAAAAGGTTAATTTGAGCAAAAGTAATTTGTTTATCATCTAAGTGCAATAGTAAGAAATTGCGAAGCTCTCTTTTACAATC,-",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.X963_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.2887+62_3028+306del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "27343443",
+                        "referenceText": "Schrock et al., 2014"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Glioma": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "7:g.116411818_116412557del",
+                "genomicLocation": "7,116411818,116412557,CCATGAGTTCTGGGCACTGGGTCAAAGTCTCCTGGGGCCCATGATAGCCGTCTTTAACAAGCTCTTTCTTTCTCTCTGTTTTAAGATCTGGGCAGTGAATTAGTTCGCTACGATGCAAGAGTACACACTCCTCATTTGGATAGGCTTGTAAGTGCCCGAAGTGTAAGCCCAACTACAGAAATGGTTTCAAATGAATCTGTAGACTACCGAGCTACTTTTCCAGAAGGTATATTTCAGTTTATTGTTCTGAGAAATACCTATACATATACCTCAGTGGGTTGTGACATTGTTGTTTATTTTTGGTTTTGCATTTATATTTTTATAAAAACCTAAAGGAAGTATTTACCTCTGCCAAGTAAGTATTTGACACAAAATTACATGGCTCTTAATTTTAAAAGAACCCATGTATATATTACATTATGATTTTAGAGTCCATAAGCTCTCATTTCACAAAAAGGTTAATTTGAGCAAAAGTAATTTGTTTATCATCTAAGTGCAATAGTAAGAAATTGCGAAGCTCTCTTTTACAATCCAGGAAGAGTTAAGTTACAAAATATACTTATTTAAATGTAAGTTGGAACTGCTACATTTTTTACCTGTTGAAGCCCAAACATTGAAATTATACTGTTAGTAATTCTTCGAAGTGTTTTCAATGAACTGTTAGTACACAGCCTTTTTCCCACCATATTCTAGGACTTGAATGTATTTTGAGACTTAGCCAAGGAAAACCTTCAATTATG,-",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.X963_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.2888-79_3028+520del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "27343443",
+                        "referenceText": "Schrock et al., 2014"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "7:g.116411874_116411897del",
+                "genomicLocation": "7,116411874,116411897,ACAAGCTCTTTCTTTCTCTCTGTT,-",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.X963_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.2888-29_2888-6del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "7:g.116411881_116411897del",
+                "genomicLocation": "7,116411881,116411897,CTTTCTTTCTCTCTGTT,-",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.X963_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.2888-22_2888-6del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "7:g.116411881_116411937del",
+                "genomicLocation": "7,116411881,116411937,CTTTCTTTCTCTCTGTTTTAAGATCTGGGCAGTGAATTAGTTCGCTACGATGCAAGA,-",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.X963_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.2888-22_2922del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "7:g.116411860_116411888del",
+                "genomicLocation": "7,116411860,116411888,GATAGCCGTCTTTAACAAGCTCTTTCTTT,-",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.*963*",
+                "vepPredictedVariantClassification": "Intron",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.2888-43_2888-15del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "7:g.116411879_116411896del",
+                "genomicLocation": "7,116411879,116411896,CTCTTTCTTTCTCTCTGT,-",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.X963_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.2888-24_2888-7del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "7:g.116412046A>G",
+                "genomicLocation": "7,116412046,116412046,A,G",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.X1010_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.3028+3A>G",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 16,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 16
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 14,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 14
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 3,
+                        "unknownVariantsCount": 1,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 3
+                        },
+                        "unknownVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 1
+                        },
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "7:g.116411879_116411897del",
+                "genomicLocation": "7,116411879,116411897,CTCTTTCTTTCTCTCTGTT,-",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.X963_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.2888-24_2888-6del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "7:g.116411887_116411906del",
+                "genomicLocation": "7,116411887,116411906,TTCTCTCTGTTTTAAGATCT,-",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.X963_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.2888-16_2891del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "7:g.116412043G>A",
+                "genomicLocation": "7,116412043,116412043,G,A",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.D1010N",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.3028G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 38,
+                        "unknownVariantsCount": 1,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 35,
+                            "Salivary Gland Cancer": 1,
+                            "Glioma": 1,
+                            "Cancer of Unknown Primary": 1
+                        },
+                        "unknownVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 1
+                        },
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 34,
+                        "unknownVariantsCount": 1,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 31,
+                            "Cancer of Unknown Primary": 1,
+                            "Glioma": 1,
+                            "Salivary Gland Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 1
+                        },
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "7:g.116411885_116411897del",
+                "genomicLocation": "7,116411885,116411897,CTTTCTCTCTGTT,-",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.X963_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.2888-18_2888-6del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "7:g.116412041_116412044del",
+                "genomicLocation": "7,116412041,116412044,AAGG,-",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.X1009_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.3026_3028+1del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "7:g.116411881_116411895del",
+                "genomicLocation": "7,116411881,116411895,CTTTCTTTCTCTCTG,-",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.X963_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.2888-22_2888-8del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "7:g.116411867_116411882del",
+                "genomicLocation": "7,116411867,116411882,GTCTTTAACAAGCTCT,-",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.*963*",
+                "vepPredictedVariantClassification": "Intron",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.2888-36_2888-21del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "7:g.116412044G>A",
+                "genomicLocation": "7,116412044,116412044,G,A",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.X1010_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.3028+1G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 19,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 16,
+                            "Cancer of Unknown Primary": 1,
+                            "Glioma": 2
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 1,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 14,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 11,
+                            "Glioma": 2,
+                            "Cancer of Unknown Primary": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "7:g.116411876_116411896del",
+                "genomicLocation": "7,116411876,116411896,AAGCTCTTTCTTTCTCTCTGT,-",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.X963_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.2888-27_2888-7del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "7:g.116411867_116411890del",
+                "genomicLocation": "7,116411867,116411890,GTCTTTAACAAGCTCTTTCTTTCT,-",
+                "transcriptId": "ENST00000397752",
+                "vepPredictedProteinEffect": "p.*963*",
+                "vepPredictedVariantClassification": "Intron",
+                "revisedProteinEffect": "p.D963_D1010del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000397752.3:c.2888-36_2888-13del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "0",
+                        "referenceText": "Confirmed by MSK Clinical Bioinformatics Team (Unpublished)"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1800
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 313
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1429
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5652
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "PIK3R1",
+        "transcriptId": "ENST00000521381",
+        "genomicLocationDescription": "Indels and substitutions flanking exon 11 (e.g. 5:67589663G>A)",
+        "defaultEffect": "splice",
+        "comment": "Skipping of exon 11",
+        "context": "Recurrent in breast and uterine cancer",
+        "revisedProteinEffects": [
+            {
+                "variant": "5:g.67589663G>C",
+                "genomicLocation": "5,67589663,67589663,G,C",
+                "transcriptId": "ENST00000521381",
+                "vepPredictedProteinEffect": "p.X475_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.D434_E476del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000521381.1:c.1425+1G>C",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "25488983",
+                        "referenceText": "Lucas et al., 2014"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 2,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Breast Cancer": 1,
+                            "Glioma": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2693
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 453
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 2,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Breast Cancer": 1,
+                            "Glioma": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2240
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5323
+                    }
+                },
+                "therapeuticLevel": null
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "FLT3",
+        "transcriptId": "ENST00000241453",
+        "genomicLocationDescription": "Indels around tyrosine kinase (e.g. 13:28608214_28608215insTT...)",
+        "defaultEffect": "splice",
+        "comment": "Internal Tandem Duplication",
+        "context": "Recurrent alteration in AML",
+        "revisedProteinEffects": [
+            {
+                "variant": "13:g.28608217_28608218insCCAAACTCTAAATTTTCTCTTGGAAACTCCCATTTGAGATCATATTCATATTCTCTG",
+                "genomicLocation": "13,28608217,28608218,-,CCAAACTCTAAATTTTCTCTTGGAAACTCCCATTTGAGATCATATTCATATTCTCTG",
+                "transcriptId": "ENST00000241453",
+                "vepPredictedProteinEffect": "p.X594_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.E598_F612dup",
+                "revisedVariantClassification": "Splice_Exon_Extension_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Ins",
+                "hgvsc": "ENST00000241453.7:c.1782_1837+1dup",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31285539",
+                        "referenceText": "Zhang et al., 2020"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1268
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 327
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1068
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6689
+                    }
+                },
+                "therapeuticLevel": null
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "ATM",
+        "transcriptId": "ENST00000278616",
+        "genomicLocationDescription": "Mutations at canonical splice sites predicted to alter splicing",
+        "defaultEffect": "missense, splice",
+        "comment": "Splice leads to exon skip, frameshift and inframe deletion",
+        "context": "In ataxia telangiectasia and familial prostate cancer, increase the risk of breast and pancreatic cancer",
+        "revisedProteinEffects": [
+            {
+                "variant": "11:g.108115753G>A",
+                "genomicLocation": "11,108115753,108115753,G,A",
+                "transcriptId": "ENST00000278616",
+                "vepPredictedProteinEffect": "p.G301S",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.C222Qfs*2",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000278616.4:c.901G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 4370
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 616
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 3361
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 10386
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "11:g.108127067G>A",
+                "genomicLocation": "11,108127067,108127067,G,A",
+                "transcriptId": "ENST00000278616",
+                "vepPredictedProteinEffect": "p.X750_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.I709_K750del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000278616.4:c.2250G>A",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "9887333",
+                        "referenceText": "Sandoval et al., 1999"
+                    },
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 8,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 1,
+                            "Colorectal Cancer": 1,
+                            "Pancreatic Cancer": 1,
+                            "Cancer of Unknown Primary": 2,
+                            "Prostate Cancer": 2,
+                            "Germ Cell Tumor": 1
+                        },
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 4370
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 616
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 3361
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 3,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Endometrial Cancer": 1,
+                            "Colorectal Cancer": 1,
+                            "Leukemia": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 10386
+                    }
+                },
+                "mutationOrigin": "germline",
+                "variantNote": "This heterozygous germline variant ATM c.2250G>A variant does not change the encoded amino acid of the ATM protein (p.Lys750=), however, it falls at the last base pair of exon 14 of ATM. This variant has been identified in <0.01% of Non-Finnish European chromosomes in the genome Aggregation Database (http://gnomad.broadinstitute.org). It has been reported in combination with another pathogenic variant in individuals and families with Ataxia-telangiectasia (PMID: 9463314, 10980530, 9887333, 10330348, 19691550). It has also been reported in the heterozygous state in a BRCA1/2 negative individual undergoing multigene panel testing (PMID:26270727). An experimental study showed that this variant affects splicing and leads to exon skipping of exon 14 (PMID: 9887333). This variant is classified as pathogenic. ATM truncating mutations may increase the risk of breast cancer and pancreatic cancer (PMID: 21787400; PMID: 22585167) and have been reported in families with familial prostate cancer (PMID: 24556621.). Ataxia-telangiectasia is an autosomal recessive condition characterized by progressive cerebellar ataxia, telangiectasias, immunodeficiency, and increased cancer risks and is caused by two mutations (one affecting each allele) in the ATM gene. If an ATM mutation carrier's partner is heterozygous for a pathogenic ATM mutation, there is a 25% risk that each child would be affected by ataxia-telangiectasia.",
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "11:g.108138071T>C",
+                "genomicLocation": "11,108138071,108138071,T,C",
+                "transcriptId": "ENST00000278616",
+                "vepPredictedProteinEffect": "p.X880_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A823Vfs*5",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000278616.4:c.2638+2T>C",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Esophagogastric Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 4370
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 616
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 3361
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 10386
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "11:g.108175400A>C",
+                "genomicLocation": "11,108175400,108175400,A,C",
+                "transcriptId": "ENST00000278616",
+                "vepPredictedProteinEffect": "p.X1833_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.V1833Ifs*63",
+                "revisedVariantClassification": "Splice_Exon_Shortening_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000278616.4:c.5497-2A>C",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 4370
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 616
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 3361
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 10386
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "11:g.108198370A>C",
+                "genomicLocation": "11,108198370,108198370,A,C",
+                "transcriptId": "ENST00000278616",
+                "vepPredictedProteinEffect": "p.X2326_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.N2326_K2363del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000278616.4:c.6976-2A>C",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 4370
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 616
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 3361
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 10386
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "11:g.108198484_108198522del",
+                "genomicLocation": "11,108198484,108198522,AGGTAAGATTTTTGGAGCAACCCTTAAGATAGTTACTTA,-",
+                "transcriptId": "ENST00000278616",
+                "vepPredictedProteinEffect": "p.X2363_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.N2326_K2363del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000278616.4:c.7088_7089+37del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 4370
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 616
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 3361
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 10386
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "11:g.108214099_108214103del",
+                "genomicLocation": "11,108214099,108214103,GTGAG,-",
+                "transcriptId": "ENST00000278616",
+                "vepPredictedProteinEffect": "p.X2806_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.V2757_M2806del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000278616.4:c.8418+1_8418+5del",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 4370
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 616
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 3361
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 10386
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "11:g.108236051G>A",
+                "genomicLocation": "11,108236051,108236051,G,A",
+                "transcriptId": "ENST00000278616",
+                "vepPredictedProteinEffect": "p.X2996_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.S2996Rfs*5",
+                "revisedVariantClassification": "Splice_Exon_Shortening_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000278616.4:c.8988-1G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 4370
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 616
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 3361
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 10386
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "11:g.108202764G>A",
+                "genomicLocation": "11,108202764,108202764,G,A",
+                "transcriptId": "ENST00000278616",
+                "vepPredictedProteinEffect": "p.X2596_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.L2544_E2596del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000278616.4:c.7788G>A",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "9792409",
+                        "referenceText": "Broeks et al., 1998"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 1,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Small Bowel Cancer": 1
+                        },
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 4370
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 616
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 3361
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 10386
+                    }
+                },
+                "mutationOrigin": "germline",
+                "variantNote": "This heterozygous ATM c.7788G>A p.Glu2596Glu variant is a synonymous variant that occurs at the last nucleotide of exon 52 and does not alter the amino acid at this position. It has been identified in 0.002% of Non-Finnish European chromosomes by the Exome Aggregation Consortium (ExAC: http://exac.broadinstitute.org; dbSNP). This variant has been reported in two homozygous and one compound heterozygous individuals with ataxia-telangiectasia (PMID: 9792409 and 26693373). It has been demonstrated to cause altered splicing, leading to deletion of 53 amino acids in exon 52 (PMID: 9792409). This region includes part of the FAT domain, which has been suggested to be important for proper activity of the protein (PMID: 23532176, 25460276, 10782091, 27229179). In summary, based on the previous reports of this variant in individuals with ataxia-telangiectasia and its impact on the protein, this variant meets our criteria to be classified as pathogenic. ATM truncating mutations may increase the risk of breast cancer and pancreatic cancer (PMID: 21787400; PMID: 22585167) and have been reported in families with familial prostate cancer (PMID: 24556621.) Ataxia-telangiectasia is an autosomal recessive condition characterized by progressive cerebellar ataxia, telangiectasias, immunodeficiency, and increased cancer risks and is caused by two mutations (one affecting each allele) in the ATM gene. If an ATM mutation carrier's partner is heterozygous for a pathogenic ATM mutation, there is a 25% risk that each child would be affected by ataxia-telangiectasia.",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "11:g.108151895G>A",
+                "genomicLocation": "11,108151895,108151895,G,A",
+                "transcriptId": "ENST00000278616",
+                "vepPredictedProteinEffect": "p.X1192_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.S1135_K1192",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000278616.4:c.3576G>A",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "9887333",
+                        "referenceText": "Sandoval et al., 1999"
+                    },
+                    {
+                        "pubmedId": "16941484",
+                        "referenceText": "Cavalieri et al., 2006"
+                    },
+                    {
+                        "pubmedId": "21965147",
+                        "referenceText": "Demuth et al., 2011"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 3,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1,
+                            "Non-Small Cell Lung Cancer": 2
+                        },
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 4370
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 616
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 3361
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Skin Cancer, Non-Melanoma": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 10386
+                    }
+                },
+                "mutationOrigin": "germline",
+                "variantNote": "This heterozygous ATM c.3576G>A variant is a synonymous alteration that does not change a Lysine to another amino acid at codon 1192 (p.Lys1192=). This variant occurs in the last nucleotide of an exon and leads to aberrant splicing leading to exon skipping according to in-vitro RNA studies (PMID: 9887333, 16941484, 21965147). This variant has been identified in 4/113572 of Non-Finnish European chromosomes by the Genome Aggregation Database (http://gnomad.broadinstitute.org/;), and has been reported in multiple individuals with ataxia telangiectasia in heterozygous (in-trans with another pathogenic ATM variant) or homozygous states (PMID: 30819809, 8845835, 9443866, 9792409, 9887333, 10330348, 12552559, 16941484, 17124347). Furthermore, this variant has been detected in patients with breast, thyroid or ampullary cancers (PMID: 27599564, 30620386, 31300551). In summary, based on the previous reports of this variant in individuals with ATM associated disease and in-vitro functional studies, this variant is classified as pathogenic. ATM truncating mutations may increase the risk of breast cancer and pancreatic cancer (PMID: 21787400; PMID: 22585167) and have been reported in families with familial prostate cancer (PMID: 24556621.) Ataxia-telangiectasia is an autosomal recessive condition characterized by progressive cerebellar ataxia, telangiectasias, immunodeficiency, and increased cancer risks and is caused by two mutations (one affecting each allele) in the ATM gene. If an ATM mutation carrier's partner is heterozygous for a pathogenic ATM mutation, there is a 25% risk that each child would be affected by ataxia-telangiectasia.",
+                "therapeuticLevel": null
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "BRCA1",
+        "transcriptId": "ENST00000357654",
+        "genomicLocationDescription": "Mutations at canonical splice sites predicted to alter splicing",
+        "defaultEffect": "missense, splice, intron",
+        "comment": "Splice leads to frameshift",
+        "context": "",
+        "revisedProteinEffects": [
+            {
+                "variant": "17:g.41197820C>T",
+                "genomicLocation": "17,41197820,41197820,C,T",
+                "transcriptId": "ENST00000357654",
+                "vepPredictedProteinEffect": "p.X1823_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A1844Dfs*2",
+                "revisedVariantClassification": "Splice_Exon_Shortening_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000357654.3:c.5468-1G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2078
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 305
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1440
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6515
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "17:g.41228505C>A",
+                "genomicLocation": "17,41228505,41228505,C,A",
+                "transcriptId": "ENST00000357654",
+                "vepPredictedProteinEffect": "p.R1495M",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.A1453Gfs*9",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000357654.3:c.4484G>T",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 4,
+                        "somaticVariantsCount": 2,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Ovarian Cancer": 2,
+                            "Glioma": 1,
+                            "Breast Cancer": 1
+                        },
+                        "somaticVariantsCountByCancerType": {
+                            "Ovarian Cancer": 1,
+                            "Small Cell Lung Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2078
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 305
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Small Cell Lung Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1440
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6515
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "17:g.41258474T>C",
+                "genomicLocation": "17,41258474,41258474,T,C",
+                "transcriptId": "ENST00000357654",
+                "vepPredictedProteinEffect": "p.R71G",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.C64*",
+                "revisedVariantClassification": "Splice_Exon_Shortening_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000357654:c.211A>G",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21735045",
+                        "referenceText": "Menéndez et al., 2012"
+                    },
+                    {
+                        "pubmedId": "11385711",
+                        "referenceText": "Vega et al., 2001"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 1,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Ovarian Cancer": 1
+                        },
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2078
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6515
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1440
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 305
+                    }
+                },
+                "variantNote": "The BRCA1 c.211A>G variant changes an arginine to glycine at codon 71 (p.R71G). This variant has been identified in 1/249744 chromosomes by the Genome Aggregation Database (http://gnomad.broadinstitute.org/), and has been reported as a founder mutation in the Spanish population shown to segregate with breast and ovarian cancer in multiple families (PMID: 11385711, 23683081, 27081505, 12014998, 20215541). According to RT-PCR analysis, this variants leads to an aberrantly spliced mRNA creating a premature stop codon (p.Cys64*) (PMID: 11385711, 19123044, 20215541, 21735045). Heterozygous truncating variants in BRCA1 are known to be pathogenic. Note: this variant is also known as 330A>G in the literature. The sequence analysis indicated that 22 base pairs of exon 4 were deleted, creating with the first bases of exon 5, a termination codon at position 64",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "17:g.41258472C>T",
+                "genomicLocation": "17,41258472,41258472,C,T",
+                "transcriptId": "ENST00000357654",
+                "vepPredictedProteinEffect": "p.X71_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.C64*",
+                "revisedVariantClassification": "Splice_Exon_Shortening_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000357654:c.212+1G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21735045",
+                        "referenceText": "Menéndez et al., 2012"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2078
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6515
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1440
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 305
+                    }
+                },
+                "variantNote": "Deletion of 22 bp at the end of exon 4",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "17:g.41256985T>C",
+                "genomicLocation": "17,41256985,41256985,T,C",
+                "transcriptId": "ENST00000357654",
+                "vepPredictedProteinEffect": "p.*71*",
+                "vepPredictedVariantClassification": "Intron",
+                "revisedProteinEffect": "p.R71Sfs*20",
+                "revisedVariantClassification": "Splice_Exon_Extension_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Ins",
+                "hgvsc": "ENST00000357654:c.213-12A>G",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21735045",
+                        "referenceText": "Menéndez et al., 2012"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 1,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Breast Cancer": 1
+                        },
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2078
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6515
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1440
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 305
+                    }
+                },
+                "variantNote": "Insertion of 11 bp of intro 4 at the beginning of exon 5",
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "17:g.41234420C>A",
+                "genomicLocation": "7,116412044,116412044,G,A",
+                "transcriptId": "ENST00000357654",
+                "vepPredictedProteinEffect": "p.X1453_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.R1397Yfs*2",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000357654:c.4357+1G>T",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21735045",
+                        "referenceText": "Menéndez et al., 2012"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 19,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 16,
+                            "Cancer of Unknown Primary": 1,
+                            "Glioma": 2
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2078
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6515
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 14,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 11,
+                            "Glioma": 2,
+                            "Cancer of Unknown Primary": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1440
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 1,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 305
+                    }
+                },
+                "variantNote": "Skipping of exon 12",
+                "otherVariation": "Deletion of the first three bases of exon 14 (r.4358_4360del), leading to an in-frame deletion of the amino acid alanine at codon 1,453 (p.Ala1453del)",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "17:g.41234420del",
+                "genomicLocation": "17,41234420,41234420,C,-",
+                "transcriptId": "ENST00000357654",
+                "vepPredictedProteinEffect": "p.X1453_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A1453Qfs*3",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000357654:c.4357+1delG",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21735045",
+                        "referenceText": "Menéndez et al., 2012"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2078
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6515
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1440
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 305
+                    }
+                },
+                "variantNote": "Deletion of a guanine at the last base of exon 12 (r.4357del) because of the use of a cryptic donor splice site created by the DNA mutation",
+                "otherVariation": "Can also be a a skipping of exon 13, although in the case of c.4357+1delG this aberrant band is observed in a lower proportion; this frameshift deletion is predicted to generate a premature stop codon (p.Arg1397TyrfsX2)",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "17:g.41228504C>A",
+                "genomicLocation": "17,41228504,41228504,C,A",
+                "transcriptId": "ENST00000357654",
+                "vepPredictedProteinEffect": "p.X1495_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A1453Gfs*10",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000357654:c.4484+1G>T",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21735045",
+                        "referenceText": "Menéndez et al., 2012"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2078
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6515
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1440
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 305
+                    }
+                },
+                "variantNote": "This mutation arises in the invariant guanine in the consensus sequence of the 5' donor splice site of exon 13. cDNA analysis showed that this mutation abolishes the natural 5_ splice site of exon 13, causing complete deletion of this exon (r.4358_4484del)",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "17:g.41219622T>C",
+                "genomicLocation": "17,41219622,41219622,T,C",
+                "transcriptId": "ENST00000357654",
+                "vepPredictedProteinEffect": "p.*1692*",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.D1692Gfs*15",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Ins",
+                "hgvsc": "ENST00000357654:c.5074+3A>G",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21735045",
+                        "referenceText": "Menéndez et al., 2012"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2078
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6515
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1440
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 305
+                    }
+                },
+                "variantNote": "The BRCA1 c.5074+3A>G variant was identified in a woman with bilateral breast cancer; her mother, who was diagnosed with breast cancer at age 53 and with colorectal cancer at age 68, carried the same variant. RNA analysis of this variant shows an insertion of the first 153 bp of intron 16 (r.5074_5075ins5074+1_5074+153). the pathogenicity of this mutation may derive from the splicing anomalies detected and is supported by the co-segregation with breast cancer observed in this family.",
+                "otherVariation": "Can also be a skipping of exon 17 (r.4987_5074del), which is predicted to lead to the truncated proteins p.Val1665SerfsX8",
+                "therapeuticLevel": "LEVEL_1"
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "BRCA2",
+        "transcriptId": "ENST00000380152",
+        "genomicLocationDescription": "Mutations at canonical splice sites predicted to alter splicing",
+        "defaultEffect": "splice, intron",
+        "comment": "Splice leads to frameshift",
+        "context": "",
+        "revisedProteinEffects": [
+            {
+                "variant": "13:g.32900634A>G",
+                "genomicLocation": "13,32900634,32900634,A,G",
+                "transcriptId": "ENST00000380152",
+                "vepPredictedProteinEffect": "p.X173_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.G173Sfs*17",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000380152.3:c.517-2A>G",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 3344
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 504
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2381
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6294
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "13:g.32931878G>A",
+                "genomicLocation": "13,32931878,32931878,G,A",
+                "transcriptId": "ENST00000380152",
+                "vepPredictedProteinEffect": "p.X2540_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.L2540Qfs*10",
+                "revisedVariantClassification": "Splice_Exon_Shortening_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000380152.3:c.7618-1G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 3344
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 504
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2381
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6294
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "13:g.32954050G>A",
+                "genomicLocation": "13,32954050,32954050,G,A",
+                "transcriptId": "ENST00000380152",
+                "vepPredictedProteinEffect": "p.X3039_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.V2985Gfs*3",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000380152.3:c.9117G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 2,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Prostate Cancer": 2
+                        },
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 3344
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 504
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2381
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 2,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Skin Cancer, Non-Melanoma": 1,
+                            "Bladder Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6294
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "13:g.32919384T>G",
+                "genomicLocation": "13,32919384,32919384,T,G",
+                "transcriptId": "ENST00000380152",
+                "vepPredictedProteinEffect": "p.*2313*",
+                "vepPredictedVariantClassification": "Intron",
+                "revisedProteinEffect": "p.G2313Gfs*9",
+                "revisedVariantClassification": "Splice_Exon_Extension_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Ins",
+                "hgvsc": "ENST00000380152.3:c.6937+594T>G",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "22753590",
+                        "referenceText": "Anczuków et al., 2012"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 3344
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6294
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2381
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 504
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "13:g.32900635G>A",
+                "genomicLocation": "13,32900635,32900635,G,A",
+                "transcriptId": "ENST00000380152",
+                "vepPredictedProteinEffect": "p.X173_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.G173Sfs*19",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000380152.3:c.517-1G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21735045",
+                        "referenceText": "Menéndez et al., 2012"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 2,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Pancreatic Cancer": 1,
+                            "Prostate Cancer": 1
+                        },
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 3344
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6294
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2381
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 504
+                    }
+                },
+                "variantNote": "Leads to a skipping of exon 7 (r.517_631del)",
+                "otherVariation": "Activate a cryptic donor splice site that leads to the skipping of most of exon 6 and all of exon 7 (r.478_631del). This transcript is predicted to lead to a truncated protein (p.Val160SerfsX19) ",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "13:g.32907378A>G",
+                "genomicLocation": "13,32907378,32907378,A,G",
+                "transcriptId": "ENST00000380152",
+                "vepPredictedProteinEffect": "p.N588S",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.N588_G637delinsS",
+                "revisedVariantClassification": "Splice_Exon_Shortening_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000380152.3:c.1763A>G",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21735045",
+                        "referenceText": "Menéndez et al., 2012"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 3344
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6294
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2381
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 504
+                    }
+                },
+                "variantNote": "Identified in a woman diagnosed with breast cancer at age 31. This variant creates a new cryptic donor site, which leads to an alternative transcript consisting of an in-frame deletion of 147 nucleotides (r.1763_1909del) that, in turn, produces an in-frame deletion of 49 amino acids with the insertion of a serine (p.Asn588_Gly637delinsSer)",
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "13:g.32944538G>A",
+                "genomicLocation": "13,32944538,32944538,G,A",
+                "transcriptId": "ENST00000380152",
+                "vepPredictedProteinEffect": "p.X2778_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.I2778Yfs*15",
+                "revisedVariantClassification": "Splice_Exon_Shortening_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000380152.3:c.8332-1G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21735045",
+                        "referenceText": "Menéndez et al., 2012"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Esophagogastric Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 3344
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6294
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Esophagogastric Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2381
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 504
+                    }
+                },
+                "variantNote": "This mutation arises in the invariant dinucleotide in the consensus sequence of the 3_ acceptor splice site of exon 19. cDNA analysis of the mutation showed that this mutation abolishes the natural 3_ splice site of exon 19 and leads to the activation of a cryptic splice site 14 bp downstream. Consequently, the mutated transcript shows a 14-bp deletion at the beginning of exon 19 (r.8332_8345del).",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "13:g.32953872T>G",
+                "genomicLocation": "13,32953872,32953872,T,G",
+                "transcriptId": "ENST00000380152",
+                "vepPredictedProteinEffect": "p.*2985*",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.V2985Afs*8",
+                "revisedVariantClassification": "Splice_Exon_Extension_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Ins",
+                "hgvsc": "ENST00000380152.3:c.8954-15T>G",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21735045",
+                        "referenceText": "Menéndez et al., 2012"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 3344
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6294
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2381
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 504
+                    }
+                },
+                "variantNote": "It creates a new cryptic donor site that leads to an alternative transcript with an insertion of the last 14 nucleotides of intron 22 (r.8953_8954ins8954-14_8954-1), generating a truncated protein (p.Val2985AlafsX8). Segregation analysis showed that the two sisters with breast cancer (diagnosed at 29 and 40 years old, respectively) are carriers of this variant, which was inherited from their unaffected father whose history is non-informative of HBOCS.",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "13:g.32953882A>G",
+                "genomicLocation": "13,32953882,32953882,A,G",
+                "transcriptId": "ENST00000380152",
+                "vepPredictedProteinEffect": "p.X2985_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.V2985Dfs*34",
+                "revisedVariantClassification": "Splice_Exon_Extension_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Ins",
+                "hgvsc": "ENST00000380152.3:c.8954-5A>G",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21735045",
+                        "referenceText": "Menéndez et al., 2012"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 2,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Endometrial Cancer": 1,
+                            "Prostate Cancer": 1
+                        },
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 3344
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6294
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 2381
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 504
+                    }
+                },
+                "variantNote": "It creates a novel cryptic donor site that leads to an alternative transcript with an insertion of the last four nucleotides of intron 22 (r.8953_8954ins8954-4_8954-1), generating a truncated protein (p.Val2985AspfsX34). The variant was observed in a young female patient with metachronic bilateral cancer diagnosed at 36 and 42 years who has no relative affected by tumors associated with HBOCS.",
+                "therapeuticLevel": "LEVEL_1"
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "BRIP1",
+        "transcriptId": "ENST00000259008",
+        "genomicLocationDescription": "Mutations at canonical splice sites predicted to alter splicing",
+        "defaultEffect": "splice",
+        "comment": "Skip exon 5",
+        "context": "Reported in individuals with breast and ovarian cancers",
+        "revisedProteinEffects": [
+            {
+                "variant": "17:g.59926490C>T",
+                "genomicLocation": "17,59926490,59926490,C,T",
+                "transcriptId": "ENST00000259008",
+                "vepPredictedProteinEffect": "p.X169_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.D127Dfs*1",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000259008.2:c.507G>A",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "29368626",
+                        "referenceText": "Weber-Lassalle et al., 2018"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 1,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Endometrial Cancer": 1
+                        },
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1202
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 247
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 914
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5013
+                    }
+                },
+                "mutationOrigin": "germline",
+                "variantNote": "This silent sequence change affects codon 169 of the BRIP1 mRNA and does not change the encoded amino acid sequence (p.Gln169=). This variant falls at the last nucleotide of BRIP1 exon 5. This variant is absent from large population databases (1000 Genomes, ESP, and gnomAD), and has been reported in the literature in individuals with breast and ovarian cancers (PMID: 29368626). An experimental study using patient RNA showed that this variant led to skipping of exon 5 and a prematurely truncated protein product (PMID: 29368626). In summary, although additional studies are required to fully establish its clinical significance, this BRIp1 c.507G>A p.Gln169= variant is classified as likely pathogenic. Heterozygous pathogenic variants in BRIP1 have been associated with an increased risk of ovarian cancer (PMID: 26315354, 2196457) and may increase the risk of breast cancer (PMID: 17033622). Biallelic mutations in BRIP1 have been associated with Fanconi Anemia, an autosomal recessive condition characterized by physical abnormalities, bone marrow failure, and increased risk of malignancy. If a BRIP1 mutation carrier's partner is heterozygous for a pathogenic BRIP1 mutation, there is a 25% risk that each child would be affected by Fanconi Anemia.",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "17:g.59938807C>T",
+                "genomicLocation": "17,59938807,59938807,C,T",
+                "transcriptId": "ENST00000259008",
+                "vepPredictedProteinEffect": "p.X31_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.M1_S31del",
+                "revisedVariantClassification": "Splice_Exon_Skip_Non_Start",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000259008.2:c.93+1G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1202
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 247
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 914
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 5013
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "CDH1",
+        "transcriptId": "ENST00000261769",
+        "genomicLocationDescription": "Mutations at canonical splice sites predicted to alter splicing",
+        "defaultEffect": "missense, splice",
+        "comment": "Splice leads to frameshift(exon 11) and nonsense(exon 10)",
+        "context": "",
+        "revisedProteinEffects": [
+            {
+                "variant": "16:g.68849663G>A",
+                "genomicLocation": "16,68849663,68849663,G,A",
+                "transcriptId": "ENST00000261769",
+                "vepPredictedProteinEffect": "p.X522_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.T523*",
+                "revisedVariantClassification": "Splice_Exon_Extension_Nonsense",
+                "revisedStandardVariantClassification": "Nonsense_Mutation",
+                "hgvsc": "ENST00000261769.5:c.1565+1G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 1,
+                        "somaticVariantsCount": 12,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "somaticVariantsCountByCancerType": {
+                            "Esophagogastric Cancer": 3,
+                            "Colorectal Cancer": 4,
+                            "Breast Cancer": 3,
+                            "Glioma": 1,
+                            "Cancer of Unknown Primary": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2298
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 2,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 357
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 11,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 4,
+                            "Breast Cancer": 3,
+                            "Esophagogastric Cancer": 2,
+                            "Cancer of Unknown Primary": 1,
+                            "Glioma": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1987
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6194
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "16:g.68853328G>A",
+                "genomicLocation": "16,68853328,68853328,G,A",
+                "transcriptId": "ENST00000261769",
+                "vepPredictedProteinEffect": "p.G571S",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.Y523Ffs*15",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000261769.5:c.1711G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2298
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 357
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1987
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6194
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "16:g.68845762G>A",
+                "genomicLocation": "16,68845762,68845762,G,A",
+                "transcriptId": "ENST00000261769",
+                "vepPredictedProteinEffect": "p.X336_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.S337Vfs*14",
+                "revisedVariantClassification": "Splice_Exon_Extension_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Ins",
+                "hgvsc": "ENST00000261769.5:c.1008G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "8127895",
+                        "referenceText": "Oda et al., 1994"
+                    },
+                    {
+                        "pubmedId": "18427545",
+                        "referenceText": "Karam et al., 2008"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 1,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Esophagogastric Cancer": 1
+                        },
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 2298
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6194
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 1987
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 1,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 357
+                    }
+                },
+                "variantNote": "The heterozygous germline variant, CDH1 c.1008G>A (p.Glu336=) is located at the last nucleotide of exon 7 of the CDH1 gene. This variant is absent from large population databases (1000 Genomes, ESP, and gnomAD) and has been reported in an individual affected with diffuse gastric cancer (PMID: 27730413). Experimental studies and analysis of RNA demonstrated that this variant leads to aberrant splicing (PMID: 8127895, 18427545). Additionally, a different variant at this position (c.1008G>T) has been reported in a family affected with hereditary diffuse gastric cancer (PMID: 9537325, 19725995). In summary, although additional studies are required to fully establish its clinical significance, this c.1008G>A variant is classified as likely pathogenic.\r\nPathogenic variants in CDH1 cause hereditary diffuse gastric cancer which is an autosomal dominant characterized by susceptibility to diffuse gastric cancer (also referred to as signet ring carcinoma or isolated cell-type carcinoma) and lobular breast cancer (https://www.ncbi.nlm.nih.gov/books/NBK1139/). Relatives of an individual with a pathogenic CDH1 variant have up-to 50% probability of carrying the same variant, and carriers are at an increased risk of developingCDH1-associated disease.",
+                "otherVariation": "Can also be 25, 42, 150 bp intron 7 insertion, and whole intron 7 insertions",
+                "therapeuticLevel": null
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "CHEK2",
+        "transcriptId": "ENST00000328354",
+        "genomicLocationDescription": "Mutations at canonical splice sites predicted to alter splicing",
+        "defaultEffect": "splice",
+        "comment": "Splice leads to frameshift",
+        "context": "",
+        "revisedProteinEffects": [
+            {
+                "variant": "22:g.29121230C>T",
+                "genomicLocation": "22,29121230,29121230,C,T",
+                "transcriptId": "ENST00000328354",
+                "vepPredictedProteinEffect": "p.X148_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.E149Ifs*5",
+                "revisedVariantClassification": "Splice_Exon_Extension_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Ins",
+                "hgvsc": "ENST00000328354.6:c.444+1G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 13,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Breast Cancer": 2,
+                            "Bladder Cancer": 1,
+                            "Colorectal Cancer": 2,
+                            "Prostate Cancer": 2,
+                            "Non-Small Cell Lung Cancer": 1,
+                            "Peripheral Nervous System": 1,
+                            "Glioma": 1,
+                            "Melanoma": 2,
+                            "Pancreatic Cancer": 1
+                        },
+                        "somaticVariantsCountByCancerType": {
+                            "Mesothelioma": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1307
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 148
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Mesothelioma": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 595
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 4512
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "PALB2",
+        "transcriptId": "ENST00000261584",
+        "genomicLocationDescription": "Mutations at canonical splice sites predicted to alter splicing",
+        "defaultEffect": "splice",
+        "comment": "Splice leads to exon 9 or exon 6 skipping",
+        "context": "",
+        "revisedProteinEffects": [
+            {
+                "variant": "16:g.23634452C>G",
+                "genomicLocation": "16,23634452,23634452,C,G",
+                "transcriptId": "ENST00000261584",
+                "vepPredictedProteinEffect": "p.X945_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A946_G999del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000261584.4:c.2835-1G>C",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1156
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 205
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 883
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 4771
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "16:g.23640597C>A",
+                "genomicLocation": "16,23640597,23640597,C,A",
+                "transcriptId": "ENST00000261584",
+                "vepPredictedProteinEffect": "p.X839_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.T839_K862del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000261584.4:c.2515-1G>T",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 1,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Pancreatic Cancer": 1
+                        },
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1156
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 205
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 883
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 4771
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "RAD51D",
+        "transcriptId": "ENST00000590016",
+        "genomicLocationDescription": "Mutations at canonical splice sites predicted to alter splicing",
+        "defaultEffect": "splice",
+        "comment": "Splice leads to frameshift exon truncation",
+        "context": "",
+        "revisedProteinEffects": [
+            {
+                "variant": "17:g.33428057T>A",
+                "genomicLocation": "17,33428057,33428057,T,A",
+                "transcriptId": "ENST00000590016",
+                "vepPredictedProteinEffect": "p.X302_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.P322Vfs*5",
+                "revisedVariantClassification": "Splice_Exon_Shortening_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000590016.1:c.964-2A>T",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "31843900",
+                        "referenceText": "Casadei et al., 2019"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 1,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Endometrial Cancer": 1
+                        },
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 274
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 88
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 167
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 3301
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "MLH1",
+        "transcriptId": "ENST00000231790",
+        "genomicLocationDescription": "Last nucleotide of exon 15;Alterations on the ESE motifs cause deletion of exons",
+        "defaultEffect": "splice",
+        "comment": "Skipping of exon 15 and leads to an out-of-frame transcript and premature protein truncation; Alters number of ESEs affecting transcription",
+        "context": "In Lynch syndrome colorectal cancer and multiple cancer types",
+        "revisedProteinEffects": [
+            {
+                "variant": "3:g.37083822G>A",
+                "genomicLocation": "3,37083822,37083822,G,A",
+                "transcriptId": "ENST00000231790",
+                "vepPredictedProteinEffect": "p.X577_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.S556Rfs*13",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000231790.2:c.1731G>A",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "16341550",
+                        "referenceText": "Pagenstecher et al., 2006"
+                    },
+                    {
+                        "pubmedId": "18561205",
+                        "referenceText": "Tournier et al., 2008"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 1,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Pancreatic Cancer": 1
+                        },
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 973
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 181
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 751
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 6,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 5,
+                            "Endometrial Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6319
+                    }
+                },
+                "mutationOrigin": "germline",
+                "variantNote": "The heterozygous germline variant, MLH1 c.1731G>A (p.Ser577Ser), results in a silent mutation and occurs at the last nucleotide of exon 15. This variant is absent from the major population databases (1000G, ESP and gnomAD). It is a well known pathogenic variant that has been reported in several individuals and families with Lynch syndrome (PMID: 16341550, 15849733, 20223024, 26300997, 14635101, 16216036, 16395668, 19669161). Experimental studies using mRNA isolated from patients blood as well as a reporter minigene assay showed that this variant results in the skipping of exon 15 and leads to an out-of-frame transcript and premature protein truncation (PMID: 16341550, 18561205, 16451135). In summary, based on the previous reports of this variant in individuals with MLH1 associated cancers and its truncating effect on the protein, this variant meets our criteria to be classified as pathogenic. Lynch syndrome is an autosomal dominant condition that confers an increased risk for colorectal cancer and endometrial cancers as well as other cancers. There is a 50% chance that each child would inherit this variant from a carrier parent.",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "3:g.37059048C>T",
+                "genomicLocation": "3,37059048,37059048,C,T",
+                "transcriptId": "ENST00000231790",
+                "vepPredictedProteinEffect": "p.A281V",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.H264Lfs*2",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000231790.2:c.842C>T",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "16995940",
+                        "referenceText": "Lastella et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Appendiceal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 973
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 1,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 181
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Appendiceal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 751
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6319
+                    }
+                },
+                "variantNote": "Alterations on the ESE motifs cause deletion of exons, affects splicing across multiple cancer types",
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.37090087G>C",
+                "genomicLocation": "3,37090087,37090087,G,C",
+                "transcriptId": "ENST00000231790",
+                "vepPredictedProteinEffect": "p.R659P",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.E633_E663del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000231790.2:c.1976G>C",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "16995940",
+                        "referenceText": "Lastella et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 973
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 181
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 751
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6319
+                    }
+                },
+                "variantNote": "Alterations on the ESE motifs cause deletion of exons, affects splicing across multiple cancer types",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "3:g.37050394C>T",
+                "genomicLocation": "3,37050394,37050394,C,T",
+                "transcriptId": "ENST00000231790",
+                "vepPredictedProteinEffect": "p.X181_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.G181Gfs*20",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000231790.2:c.543C>T",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "28334867",
+                        "referenceText": "Yamaguchi et al., 2017"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 973
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 181
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 751
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6319
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "3:g.37053309A>G",
+                "genomicLocation": "3,37053309,37053309,A,G",
+                "transcriptId": "ENST00000231790",
+                "vepPredictedProteinEffect": "p.X182_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.R84Sfs*5",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000231790.2:c.546-2A>G",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 973
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6319
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 751
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 1,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 181
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            },
+            {
+                "variant": "3:g.37053590G>T",
+                "genomicLocation": "3,37053590,37053590,G,T",
+                "transcriptId": "ENST00000231790",
+                "vepPredictedProteinEffect": "p.R226L",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.Q197Rfs*7",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000231790.2:c.677G>T",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "12362047",
+                        "referenceText": "Kurzawski et al., 2002"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 1,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 973
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6319
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 751
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 181
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.37059089A>C",
+                "genomicLocation": "3,37059089,37059089,A,C",
+                "transcriptId": "ENST00000231790",
+                "vepPredictedProteinEffect": "p.S295R",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.H264Lfs*1",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000231790.2:c.883A>C",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "12362047",
+                        "referenceText": "Kurzawski et al., 2002"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 973
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6319
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 751
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 181
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "3:g.37067499G>C",
+                "genomicLocation": "3,37067499,37067499,G,C",
+                "transcriptId": "ENST00000231790",
+                "vepPredictedProteinEffect": "p.X470_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.T347Kfs*7",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000231790.2:c.1409+1G>C",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "12362047",
+                        "referenceText": "Kurzawski et al., 2002"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 1,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Renal Cell Carcinoma": 1
+                        },
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 973
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 6319
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 751
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 181
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": "LEVEL_1"
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "EGFR",
+        "transcriptId": "ENST00000275493",
+        "genomicLocationDescription": "5 bases upstream from the 5' end of exon 20 (7:g.55248980_55248981insTCCAGGAAGCCT)",
+        "defaultEffect": "splice",
+        "comment": "Inset a repeated sequence from 55248980-55248992",
+        "context": "Recurrent in lung cancer, can be linked to Level 1 TKIs",
+        "revisedProteinEffects": [
+            {
+                "variant": "7:g.55248980_55248981insTCCAGGAAGCCT",
+                "genomicLocation": "7,55248980,55248981,-,TCCAGGAAGCCT",
+                "transcriptId": "ENST00000275493",
+                "vepPredictedProteinEffect": "p.X762_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.A763_Y764insFQEA",
+                "revisedVariantClassification": "Splice_Exon_Extension_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Ins",
+                "hgvsc": "ENST00000275493.2:c.2284-5_2290dup",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "31715539",
+                        "referenceText": "Sousa et al., 2020"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 9,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 9
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 4070
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 512
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 6,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 6
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 3462
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 11009
+                    }
+                },
+                "therapeuticLevel": "LEVEL_1"
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "TP53",
+        "transcriptId": "ENST00000269305",
+        "genomicLocationDescription": "c.375+5G mutations flanking exon 4",
+        "defaultEffect": "splice",
+        "comment": "Splice leads to whole exon 4 skipping inframe deletion or partial exon 4 skipping frameshift",
+        "context": "Recurrent in many cancer types and results in P53 protein loss of function",
+        "revisedProteinEffects": [
+            {
+                "variant": "17:g.7579307C>A",
+                "genomicLocation": "17,7579307,7579307,C,A",
+                "transcriptId": "ENST00000269305",
+                "vepPredictedProteinEffect": "p.X125_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.S33_T125del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000269305.4:c.375+5G>T",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "34505757",
+                        "referenceText": "Chui et al., 2021"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 31790
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 3859
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 27411
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 49,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Colorectal Cancer": 6,
+                            "Pancreatic Cancer": 6,
+                            "Small Cell Lung Cancer": 2,
+                            "Endometrial Cancer": 2,
+                            "Cancer of Unknown Primary": 3,
+                            "Ovarian Cancer": 6,
+                            "Non-Small Cell Lung Cancer": 10,
+                            "Breast Cancer": 3,
+                            "Peritoneal Cancer, NOS": 1,
+                            "Bladder Cancer": 2,
+                            "Anal Cancer": 1,
+                            "Glioma": 3,
+                            "Soft Tissue Sarcoma": 2,
+                            "Sellar Tumor": 1,
+                            "Esophagogastric Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 8966
+                    }
+                },
+                "otherVariation": "Partial exon 4 skip, p.G59Vfs*23, Splice_Exon_Shortening_Frame_Shift",
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "17:g.7579312C>A",
+                "genomicLocation": "17,7579312,7579312,C,A",
+                "transcriptId": "ENST00000269305",
+                "vepPredictedProteinEffect": "p.X125_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.S33_T125del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000269305.4:c.375G>T",
+                "confirmed": true,
+                "references": [
+                    {
+                        "pubmedId": "11420676",
+                        "referenceText": "Varley et al., 2001"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 31790
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 25,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 3859
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 27411
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 124,
+                        "unknownVariantsCount": 2,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 78,
+                            "Colorectal Cancer": 6,
+                            "Cancer of Unknown Primary": 5,
+                            "Small Cell Lung Cancer": 9,
+                            "Esophagogastric Cancer": 1,
+                            "Prostate Cancer": 1,
+                            "Breast Cancer": 3,
+                            "Pancreatic Cancer": 4,
+                            "Head and Neck Cancer": 5,
+                            "Soft Tissue Sarcoma": 1,
+                            "Bladder Cancer": 4,
+                            "Hepatobiliary Cancer": 1,
+                            "Skin Cancer, Non-Melanoma": 2,
+                            "Bone Cancer": 1,
+                            "Adrenocortical Carcinoma": 1,
+                            "Uterine Sarcoma": 1,
+                            "Endometrial Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {
+                            "Hepatobiliary Cancer": 1,
+                            "Leukemia": 1
+                        },
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 8966
+                    }
+                },
+                "mutationOrigin": "germline",
+                "variantNote": "The heterozygous germline variant, TP53 c.375G>T (Thr125=), is located at the last nucleotide of exon 4 of the TP53 gene. This variant is absent from large population databases (1000 Genomes, ESP, and gnomAD). It has been reported in a family with Li Fraumeni syndrome (PMID: 11420676). In vitro studies and analysis of RNA from patient cells demonstrated that this variant leads to aberrant splicing (PMID: 11420676, 25730903). Two other variants at this position (c.375G>A and c.375G>C) have been reported in individuals and families with Li Fraumeni syndrome (PMID: 9242456, 10864200, 11420676, 24382691, 31105275). In summary, although additional studies are required to fully establish its clinical significance, based on its previous report in an individual with Li Fraumeni syndrome and its demonstrated impact on splicing, this c.375G>T (p.?) variant is classified as likely pathogenic. Li-Fraumeni syndrome (LFS) is an autosomal dominant cancer predisposition syndrome associated with an increased risk of tumors including soft tissue sarcoma, osteosarcoma, pre-menopausal breast cancer, brain tumors, adrenocortical carcinoma (ACC), and leukemias (http://www.ncbi.nlm.nih.gov/books/NBK1311/).",
+                "therapeuticLevel": null
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "F11",
+        "transcriptId": "ENST00000403665",
+        "genomicLocationDescription": "Alterations in Exon Splice Enhancement Sites (ESE) affecting multiple exons",
+        "defaultEffect": "missense",
+        "comment": "Alters number of ESEs affecting transcription and causing aberrant splicing",
+        "context": "Largely found in cancer-related thrombosis",
+        "revisedProteinEffects": [
+            {
+                "variant": "4:g.187208954G>A",
+                "genomicLocation": "4,187208954,187208954,G,A",
+                "transcriptId": "ENST00000403665",
+                "vepPredictedProteinEffect": "p.E565K",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.D526_G572del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000403665.2:c.1693G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21718436",
+                        "referenceText": "Zucker et al., 2011"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 0
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 170
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 0
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "4:g.187201659G>A",
+                "genomicLocation": "4,187201659,187201659,G,A",
+                "transcriptId": "ENST00000403665",
+                "vepPredictedProteinEffect": "p.G350R",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.K343_E379del",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000403665.2:c.1060G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21718436",
+                        "referenceText": "Zucker et al., 2011"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 0
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 1,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 170
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 0
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "4:g.187197405C>T",
+                "genomicLocation": "4,187197405,187197405,C,T",
+                "transcriptId": "ENST00000403665",
+                "vepPredictedProteinEffect": "p.P206S",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.A199_R252del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000403665.2:c.616C>T",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21718436",
+                        "referenceText": "Zucker et al., 2011"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 0
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 170
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 0
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 2
+                    }
+                },
+                "therapeuticLevel": null
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "MSH2",
+        "transcriptId": "ENST00000233146",
+        "genomicLocationDescription": "Alterations on the ESE motifs cause skipping of exons",
+        "defaultEffect": "missense",
+        "comment": "Alters number of ESEs affecting transcription",
+        "context": "Affects splicing across multiple cancer types",
+        "revisedProteinEffects": [
+            {
+                "variant": "2:g.47641421C>T",
+                "genomicLocation": "2,47641421,47641421,C,T",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.S269L",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.V265_Q314del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000233146.2:c.806C>T",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "16995940",
+                        "referenceText": "Lastella et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1168
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 180
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 944
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 7387
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "2:g.47641430C>T",
+                "genomicLocation": "2,47641430,47641430,C,T",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.A272V",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.V265_Q314del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000233146.2:c.815C>T",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "16995940",
+                        "referenceText": "Lastella et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 5,
+                        "unknownVariantsCount": 1,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Skin Cancer, Non-Melanoma": 1,
+                            "Cancer of Unknown Primary": 1,
+                            "Endometrial Cancer": 1,
+                            "Small Bowel Cancer": 1,
+                            "Breast Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {
+                            "Soft Tissue Sarcoma": 1
+                        },
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1168
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 180
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 3,
+                        "unknownVariantsCount": 1,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Endometrial Cancer": 1,
+                            "Small Bowel Cancer": 1,
+                            "Breast Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {
+                            "Soft Tissue Sarcoma": 1
+                        },
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 944
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 7387
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "2:g.47693802G>T",
+                "genomicLocation": "2,47693802,47693802,G,T",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.D506Y",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.G504Afs*3",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000233146.2:c.1516G>T",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "16995940",
+                        "referenceText": "Lastella et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 2,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 2
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1168
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 180
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Non-Small Cell Lung Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 944
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 7387
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "2:g.47693886C>T",
+                "genomicLocation": "2,47693886,47693886,C,T",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.R534C",
+                "vepPredictedVariantClassification": "Missense_Mutation",
+                "revisedProteinEffect": "p.G504Afs*3",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000233146.2:c.1600C>T",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "16995940",
+                        "referenceText": "Lastella et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 4,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Melanoma": 3,
+                            "Endometrial Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1168
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 180
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 4,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Melanoma": 3,
+                            "Endometrial Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 944
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 7387
+                    }
+                },
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "2:g.47641560A>T",
+                "genomicLocation": "2,47641560,47641560,A,T",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.X314_splice",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.V265_Q314del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000233146.2:c.942+3A>T",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "33259954",
+                        "referenceText": "Oldfield et al., 2021"
+                    },
+                    {
+                        "pubmedId": "12362047",
+                        "referenceText": "Kurzawski et al., 2002"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 21,
+                        "somaticVariantsCount": 3,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Pancreatic Cancer": 1,
+                            "Colorectal Cancer": 7,
+                            "Prostate Cancer": 1,
+                            "Endometrial Cancer": 4,
+                            "Bladder Cancer": 2,
+                            "Bone Cancer": 1,
+                            "Soft Tissue Sarcoma": 2,
+                            "Miscellaneous Neuroepithelial Tumor": 1,
+                            "Small Bowel Cancer": 1,
+                            "Tubular Adenoma of the Colon": 1
+                        },
+                        "somaticVariantsCountByCancerType": {
+                            "Thyroid Cancer": 1,
+                            "Esophagogastric Cancer": 1,
+                            "Colorectal Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1168
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 1,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Melanoma": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 7387
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 3,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {
+                            "Thyroid Cancer": 1,
+                            "Colorectal Cancer": 1,
+                            "Esophagogastric Cancer": 1
+                        },
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 944
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 180
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "2:g.47693952G>C",
+                "genomicLocation": "2,47693952,47693952,G,C",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.*554*",
+                "vepPredictedVariantClassification": "Splice_Region",
+                "revisedProteinEffect": "p.G504Afs*3",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000233146.2:c.1661+5G>C",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "33259954",
+                        "referenceText": "Oldfield et al., 2021"
+                    },
+                    {
+                        "pubmedId": "12362047",
+                        "referenceText": "Kurzawski et al., 2002"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1168
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 7387
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 944
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 180
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "2:g.47637512G>T",
+                "genomicLocation": "2,47637512,47637512,G,T",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.X215_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.A123_Q215del",
+                "revisedVariantClassification": "Splice_Exon_Skip_In_Frame",
+                "revisedStandardVariantClassification": "In_Frame_Del",
+                "hgvsc": "ENST00000233146.2:c.645+1G>T",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "12362047",
+                        "referenceText": "Kurzawski et al., 2002"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1168
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 7387
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 944
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 180
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "2:g.47703711G>C",
+                "genomicLocation": "2,47703711,47703711,G,C",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.X737_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.G669Gfs*7",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000233146.2:c.2210+1G>C",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "12362047",
+                        "referenceText": "Kurzawski et al., 2002"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1168
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 7387
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 944
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 180
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": null
+            },
+            {
+                "variant": "2:g.47708011G>A",
+                "genomicLocation": "2,47708011,47708011,G,A",
+                "transcriptId": "ENST00000233146",
+                "vepPredictedProteinEffect": "p.X878_splice",
+                "vepPredictedVariantClassification": "Splice_Site",
+                "revisedProteinEffect": "p.G820Afs*2",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000233146.2:c.2634+1G>A",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "12362047",
+                        "referenceText": "Kurzawski et al., 2002"
+                    },
+                    {
+                        "pubmedId": "16451135",
+                        "referenceText": "Kurzawski et al., 2006"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 1168
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 7387
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 944
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 180
+                    }
+                },
+                "mutationOrigin": "germline",
+                "therapeuticLevel": null
+            }
+        ]
+    },
+    {
+        "hugoGeneSymbol": "RB1",
+        "transcriptId": "ENST00000267163",
+        "genomicLocationDescription": "c.1206C>T mutation on exon 12",
+        "defaultEffect": "synonymous",
+        "comment": "Disrupting the splicing enhancer element and caused skipping of exon 12",
+        "context": "Reported in an individual with unilateral retinoblastoma",
+        "revisedProteinEffects": [
+            {
+                "variant": "13:g.48947619C>T",
+                "genomicLocation": "13,48947619,48947619,C,T",
+                "transcriptId": "ENST00000267163",
+                "vepPredictedProteinEffect": "p.S402=",
+                "vepPredictedVariantClassification": "Silent",
+                "revisedProteinEffect": "p.R376Rfs*4",
+                "revisedVariantClassification": "Splice_Exon_Skip_Frame_Shift",
+                "revisedStandardVariantClassification": "Frame_Shift_Del",
+                "hgvsc": "ENST00000267163.4:c.1206C>T",
+                "confirmed": false,
+                "references": [
+                    {
+                        "pubmedId": "21763628",
+                        "referenceText": "Ahani et al., 2011"
+                    }
+                ],
+                "counts": {
+                    "mskimpact": {
+                        "germlineVariantsCount": 1,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {
+                            "Retinoblastoma": 1
+                        },
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 70067,
+                        "genePatientCount": 3880
+                    },
+                    "mskimpact_nonsignedout": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 87119,
+                        "genePatientCount": 7615
+                    },
+                    "genie": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 60702,
+                        "genePatientCount": 3317
+                    },
+                    "tcga": {
+                        "germlineVariantsCount": 0,
+                        "somaticVariantsCount": 0,
+                        "unknownVariantsCount": 0,
+                        "germlineVariantsCountByCancerType": {},
+                        "somaticVariantsCountByCancerType": {},
+                        "unknownVariantsCountByCancerType": {},
+                        "totalPatientCount": 10953,
+                        "genePatientCount": 475
+                    }
+                },
+                "variantNote": "This heterozygous RB1 c.1206C>T variant is a synonymous variant that does not alter the amino acid at this position (p.Ser402=). This variant has been identified in 3/30442 South Asian chromosomes by the Genome Aggregation Database (gnomAD: http://gnomad.broadinstitute.org). It has been reported in an individual with unilateral retinoblastoma and was demonstrated to cause abnormal splicing based on patient RNA studies (PMID 21763628). In our patient (DMG19-4863) with unilateral retinoblastoma, tumor analysis identified somatic biallelic mutations (two somatic hits) in RB1 (DMG internal data). In summary, based on the currently available data, the clinical significance of the RB1 c.1206C>T (p.Ser402=) variant is uncertain.",
+                "therapeuticLevel": null
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Starting from version v1.4.3, Genome Nexus uses the new `./generated/VUEs.json` file to store VUE data. For compatibility with older versions, adding back the previous file, `./VUEs.json`.